### PR TITLE
Fix for background and lock screen

### DIFF
--- a/app/src/main/java/com/twilio/voice/quickstart/VoiceActivity.java
+++ b/app/src/main/java/com/twilio/voice/quickstart/VoiceActivity.java
@@ -112,19 +112,25 @@ public class VoiceActivity extends AppCompatActivity {
          */
         setVolumeControlStream(AudioManager.STREAM_VOICE_CALL);
 
-        Intent intent = getIntent();
-        if (intent != null && intent.getAction() != null && intent.getAction() == VoiceActivity.ACTION_INCOMING_CALL) {
-            IncomingCallMessage incomingCallMessage = intent.getParcelableExtra(INCOMING_CALL_MESSAGE);
-            VoiceClient.handleIncomingCallMessage(getApplicationContext(), incomingCallMessage, incomingCallMessageListener);
-        } else {
-            registerReceiver();
-        }
+        /*
+         * Validates whether intent contains incoming call message and displays accept/reject dialog
+         * if incoming call is available.
+         */
+        handleIncomingCallIntent(getIntent());
+
+        registerReceiver();
 
         if (!checkPermissionForMicrophone()) {
             requestPermissionForMicrophone();
         } else {
             startGCMRegistration();
         }
+    }
+
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        handleIncomingCallIntent(intent);
     }
 
     private void startGCMRegistration() {
@@ -263,6 +269,13 @@ public class VoiceActivity extends AppCompatActivity {
         super.onPause();
         LocalBroadcastManager.getInstance(this).unregisterReceiver(voiceClientBroadcastReceiver);
         isReceiverRegistered = false;
+    }
+
+    private void handleIncomingCallIntent(Intent intent) {
+        if (intent != null && intent.getAction() != null && intent.getAction() == VoiceActivity.ACTION_INCOMING_CALL) {
+            IncomingCallMessage incomingCallMessage = intent.getParcelableExtra(INCOMING_CALL_MESSAGE);
+            VoiceClient.handleIncomingCallMessage(getApplicationContext(), incomingCallMessage, incomingCallMessageListener);
+        }
     }
 
     private void registerReceiver() {

--- a/app/src/main/java/com/twilio/voice/quickstart/gcm/VoiceGCMListenerService.java
+++ b/app/src/main/java/com/twilio/voice/quickstart/gcm/VoiceGCMListenerService.java
@@ -65,7 +65,7 @@ public class VoiceGCMListenerService extends GcmListenerService {
             intent.setAction(VoiceActivity.ACTION_INCOMING_CALL);
             intent.putExtra(VoiceActivity.INCOMING_CALL_MESSAGE, incomingCallMessage);
             intent.putExtra(VoiceActivity.INCOMING_CALL_NOTIFICATION_ID, notificationId);
-            intent.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
+            intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
 
             PendingIntent pendingIntent = PendingIntent.getActivity(this, 0, intent, PendingIntent.FLAG_ONE_SHOT);
 


### PR DESCRIPTION
When app is backgrounded, activity is not recreated, so user dialog with accept/reject does not pop up.

To avoid such behaviour modified two things:

* onNewIntent() -> validates for incoming call from resumed activity
* switched to FLAG_CLEAR_TOP