### PR TITLE
Updated pending intent flag. 

### DIFF
--- a/app/src/main/java/com/twilio/voice/quickstart/gcm/VoiceGCMListenerService.java
+++ b/app/src/main/java/com/twilio/voice/quickstart/gcm/VoiceGCMListenerService.java
@@ -75,7 +75,7 @@ public class VoiceGCMListenerService extends GcmListenerService {
             intent.putExtra(VoiceActivity.INCOMING_CALL_MESSAGE, incomingCallMessage);
             intent.putExtra(VoiceActivity.INCOMING_CALL_NOTIFICATION_ID, notificationId);
             intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-            PendingIntent pendingIntent = PendingIntent.getActivity(this, 0, intent, PendingIntent.FLAG_ONE_SHOT);
+            PendingIntent pendingIntent = PendingIntent.getActivity(this, 0, intent, PendingIntent.FLAG_CANCEL_CURRENT);
 
             /*
              * Pass the notification id and call sid to use as an identifier to cancel the


### PR DESCRIPTION
Set the pending intent  to FLAG_CANCEL_CURRENT. This flag tells the system that the old pending intent is no longer valid, it should remove it and create a new one.