### PR TITLE
Set instance to null when releasing the SoundPoolManager

### DIFF
--- a/app/src/main/java/com/twilio/voice/quickstart/SoundPoolManager.java
+++ b/app/src/main/java/com/twilio/voice/quickstart/SoundPoolManager.java
@@ -84,6 +84,7 @@ public class SoundPoolManager {
             soundPool.release();
             soundPool = null;
         }
+        instance = null;
     }
 
 }


### PR DESCRIPTION
The instance is set to `null` when calling `release()` to ensure that the `getInstance()` method creates a new instance after `release()` has been called. The singleton class is not thread-safe however, it must be created and released from the same thread.

Addresses https://github.com/twilio/voice-quickstart-android/issues/49