### PR TITLE
Fix AndroidManifest to properly propagate Firebase instance id event

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,10 +26,9 @@
         <!-- [END fcm_listener] -->
         <!-- [START instanceId_listener] -->
             <service
-                android:name=".fcm.VoiceFirebaseInstanceIDService"
-            android:exported="false">
+                android:name=".fcm.VoiceFirebaseInstanceIDService" >
             <intent-filter>
-                <action android:name="com.google.android.gms.iid.InstanceID" />
+                <action android:name="com.google.firebase.INSTANCE_ID_EVENT" />
             </intent-filter>
         </service>
         <!-- [END instanceId_listener] -->

--- a/app/src/main/java/com/twilio/voice/quickstart/VoiceActivity.java
+++ b/app/src/main/java/com/twilio/voice/quickstart/VoiceActivity.java
@@ -325,7 +325,6 @@ public class VoiceActivity extends AppCompatActivity {
      *
      */
     private void registerForCallInvites() {
-        FirebaseApp.initializeApp(this);
         final String fcmToken = FirebaseInstanceId.getInstance().getToken();
         if (fcmToken != null) {
             Log.i(TAG, "Registering with FCM");


### PR DESCRIPTION
The AndroidManifest was erroneously using the old event name associated with GCM. With this fix the `onTokenRefresh()` from the `FirebaseInstanceIdService` will be called as expected.