### PR TITLE
Stop ringing when a call is accepted or rejected

### DIFF
--- a/app/src/main/java/com/twilio/voice/quickstart/VoiceActivity.java
+++ b/app/src/main/java/com/twilio/voice/quickstart/VoiceActivity.java
@@ -281,6 +281,7 @@ public class VoiceActivity extends AppCompatActivity {
 
             @Override
             public void onClick(DialogInterface dialog, int which) {
+                soundPoolManager.stopRinging();
                 answer();
                 setCallUI();
                 alertDialog.dismiss();
@@ -293,6 +294,7 @@ public class VoiceActivity extends AppCompatActivity {
 
             @Override
             public void onClick(DialogInterface dialogInterface, int i) {
+                soundPoolManager.stopRinging();
                 activeCallInvite.reject(VoiceActivity.this);
                 alertDialog.dismiss();
             }


### PR DESCRIPTION
Previously, ringing stopped because the cancelled invite after accepting the call would get processed by `onCallInvite`. At the moment we process the cancelled invite notification as an error since the call was accepted and the invite is no longer being tracked internally. Rather than relying on the notification to stop the ringing we should stop the ringing when the dialog is clicked.