### PR TITLE
Added NotificationChannel support for Android O devices.

### DIFF
--- a/app/src/main/java/com/twilio/voice/quickstart/fcm/VoiceFirebaseMessagingService.java
+++ b/app/src/main/java/com/twilio/voice/quickstart/fcm/VoiceFirebaseMessagingService.java
@@ -94,7 +94,7 @@ public class VoiceFirebaseMessagingService extends FirebaseMessagingService {
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 NotificationChannel callInviteChannel = new NotificationChannel(VOICE_CHANNEL,
-                        "Pimary Voice Channel", NotificationManager.IMPORTANCE_DEFAULT);
+                        "Primary Voice Channel", NotificationManager.IMPORTANCE_DEFAULT);
                 callInviteChannel.setLightColor(Color.GREEN);
                 callInviteChannel.setLockscreenVisibility(Notification.VISIBILITY_PRIVATE);
                 notificationManager.createNotificationChannel(callInviteChannel);


### PR DESCRIPTION
Starting in Android O, you can create an instance of NotificationChannel for each distinct type of notification you need to send. Added NotificationChannel in the app for Android O devices.

As noted [here](https://developer.android.com/guide/topics/ui/notifiers/notifications.html), when you target Android 8.0 (API level 26), you must implement one or more notification channels to display notifications to your users. If you don't target Android 8.0 (API level 26) but your app is used on devices running Android 8.0 (API level 26), your app behaves the same as it would on devices running Android 7.1 (API level 25) or lower.

