### PR TITLE
Use beta 23.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,7 +40,7 @@ android {
 
 dependencies {
     testCompile 'junit:junit:4.12'
-    compile 'com.twilio:voice-android:2.0.0-beta22'
+    compile 'com.twilio:voice-android:2.0.0-beta23'
     compile 'com.android.support:design:26.0.2'
     compile 'com.android.support:appcompat-v7:26.0.2'
     compile 'com.squareup.retrofit:retrofit:1.9.0'


### PR DESCRIPTION
https://www.twilio.com/docs/api/voice-sdk/android/changelog#200-beta23

**2.0.0-beta23**

October 20, 2017

**Features**

* CLIENT-3987 Initialization and destruction of the VOIP stack has been moved off of the UI thread. Previously calling connect and disconnect would result in a significant amount of work done on the UI thread. We have moved this work to a dedicated thread such that any operations performed on the UI thread by the app developer will not be blocked by these operations.
* CLIENT-4106 CallGenericErrorException and CallTransportException have been removed from CallException.java. CallConnectionError has been added to CallException.java to reflect failures due to connectivity errors.

**Known issues**

* CLIENT-2985 IPv6 is not supported.