### PR TITLE
Use beta24.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,7 +40,7 @@ android {
 
 dependencies {
     testCompile 'junit:junit:4.12'
-    compile 'com.twilio:voice-android:2.0.0-beta23'
+    compile 'com.twilio:voice-android:2.0.0-beta24'
     compile 'com.android.support:design:26.0.2'
     compile 'com.android.support:appcompat-v7:26.0.2'
     compile 'com.squareup.retrofit:retrofit:1.9.0'


### PR DESCRIPTION
https://www.twilio.com/docs/api/voice-sdk/android/changelog#200-beta24

#### 2.0.0-beta24

November 3, 2017

#### Bug Fixes

- CLIENT-4099 Emulators and devices that fail to start/open the audio device now return an AudioDeviceErrorException in `onConnectFailure(...)`

#### Known issues

- CLIENT-2985 IPv6 is not supported.