### PR TITLE
Use beta25.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,7 +40,7 @@ android {
 
 dependencies {
     testCompile 'junit:junit:4.12'
-    compile 'com.twilio:voice-android:2.0.0-beta24'
+    compile 'com.twilio:voice-android:2.0.0-beta25’
     compile 'com.android.support:design:26.0.2'
     compile 'com.android.support:appcompat-v7:26.0.2'
     compile 'com.squareup.retrofit:retrofit:1.9.0'


### PR DESCRIPTION
https://www.twilio.com/docs/api/voice-sdk/android/changelog#200-beta25

#### 2.0.0-beta25

December 1 , 2017

* Programmable Voice Android SDK 2.0.0-beta25 [[bintray]](https://bintray.com/twilio/releases/voice-android/2.0.0-beta25), [[docs]](https://media.twiliocdn.com/sdk/android/voice/releases/2.0.0-beta25/docs/)

#### Features

- CLIENT-4056 
<p>
Twilio sends 2 types of notifications messages via GCM/FCM, `call` and `cancel` messages. The message type is encoded in the dictionary with the key `twi_message_type` and the values `twilio.voice.call` and `twilio.voice.cancel`. 
</p>
<p>
A `call` message is sent when someone wants to reach the registered `identity`. Passing a `call` message into `Voice.handleMessage(...)` will always result in a `CallInvite` in the `PENDING` state.
</p>
<p>
A `cancel` message is sent when a call made to this `identity` is prematurely `disconnected` by the caller, when the call is `rejected`, when the call is `ignored`, or when the call is `accepted` due to an outstanding infrastructure issue. Passing a `cancel` message into `Voice.handleMessage(...)` will result in a callback from `MessageListener.onCallInvite(...)` in the `CANCELED` state for the following scenarios:
<ul>
<li> If the caller prematurely disconnected the call.
<li> If a callee did not accept or reject the call (e.g. it was ignored).
</ul>
Passing a `cancel` message into `Voice.handleMessage(...)` will not result in any callback from `MessageListener` for the following scenarios:
<ul>
<li> This callee accepted the call.
<li> This callee rejected the call.
</ul>
</p>
<p>
Providing a message that is malformed, that has not been received from Twilio will likely lead to an `MessageListener.onError(MessageException messageException)`
</p>

#### Bug Fixes
- CLIENT-4148 - If `Call.mute()` fails, SDK now disconnects the call with `CallConnectionErrorException` in `onDisconnected(...)`.
- CLIENT-4162 - Set `messageType` of `CallInvite` to `twilio.voice.cancel` for cancelled `CallInvite`.
- CLIENT-4159 - Added error code `20151` in Voice SDK. This error surfaces when Twilio fails to authenticate with the token provided. For details please refer to the [Programmable Voice SDK Error Codes Page](https://www.twilio.com/docs/api/voice-sdk/error-codes).

#### Enhancements
- CLIENT-4010 - Improved `errorMessage` in `RegistrationException`.

#### Known issues

- CLIENT-2985 IPv6 is not supported.
