### PR TITLE
Use beta26.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,7 +40,7 @@ android {
 
 dependencies {
     testCompile 'junit:junit:4.12'
-    compile 'com.twilio:voice-android:2.0.0-beta25'
+    compile 'com.twilio:voice-android:2.0.0-beta26'
     compile 'com.android.support:design:26.0.2'
     compile 'com.android.support:appcompat-v7:26.0.2'
     compile 'com.squareup.retrofit:retrofit:1.9.0'


### PR DESCRIPTION
https://www.twilio.com/docs/api/voice-sdk/android/changelog#200-beta26

#### 2.0.0-beta26
December 13, 2017

* Programmable Voice Android SDK 2.0.0-beta26 [[bintray]](https://bintray.com/twilio/releases/voice-android/2.0.0-beta26), [[docs]](https://media.twiliocdn.com/sdk/android/voice/releases/2.0.0-beta26/docs/)

#### Bug Fixes

- CLIENT-4212 Devices or emulators that fail to start the audio device will retry with a fallback audio device implementation. By default OpenSLES will be attempted first above API 19. If OpenSLES fails an Android JNI implementation will be used. The reverse is true for API 19 and below.

#### Known issues

- CLIENT-2985 IPv6 is not supported.