### PR TITLE
Use GA 2.0.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,7 +40,7 @@ android {
 
 dependencies {
     testCompile 'junit:junit:4.12'
-    compile 'com.twilio:voice-android:2.0.0-beta29'
+    compile 'com.twilio:voice-android:2.0.1'
     compile 'com.android.support:design:26.0.2'
     compile 'com.android.support:appcompat-v7:26.0.2'
     compile 'com.squareup.retrofit:retrofit:1.9.0'


### PR DESCRIPTION
https://www.twilio.com/docs/api/voice-sdk/android/changelog#201

#### 2.0.1
December 15, 2017

* Programmable Voice Android SDK 2.0.1 [[bintray]](https://bintray.com/twilio/releases/voice-android/2.0.1), [[docs]](https://media.twiliocdn.com/sdk/android/voice/releases/2.0.1/docs/)

#### Announcement

- General Availability (GA) of Android Voice SDK.

#### Known issues

- CLIENT-2985 IPv6 is not supported.