### PR TITLE
Use 2.0.2

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,7 +40,7 @@ android {
 
 dependencies {
     testCompile 'junit:junit:4.12'
-    compile 'com.twilio:voice-android:2.0.1'
+    compile 'com.twilio:voice-android:2.0.2'
     compile 'com.android.support:design:26.0.2'
     compile 'com.android.support:appcompat-v7:26.0.2'
     compile 'com.squareup.retrofit:retrofit:1.9.0'


### PR DESCRIPTION
https://www.twilio.com/docs/api/voice-sdk/android/changelog#202

#### 2.0.2

December 21, 2017

* Programmable Voice Android SDK 2.0.2 [[bintray]](https://bintray.com/twilio/releases/voice-android/2.0.2), [[docs]](https://media.twiliocdn.com/sdk/android/voice/releases/2.0.2/docs/)

#### Bug Fixes

CLIENT-4230 DNS name servers are retrieved using LinkProperties.getDnsServers() starting with API 21 and up. Previously, devices would use the net.dns entries or fallback to 8.8.8.8 and 8.8.4.4.
Known issues

#### Known Issues

CLIENT-2985 IPv6 is not supported.