### PR TITLE
Use 2.0.4

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,7 +40,7 @@ android {
 
 dependencies {
     testCompile 'junit:junit:4.12'
-    compile 'com.twilio:voice-android:2.0.3'
+    compile 'com.twilio:voice-android:2.0.4'
     compile 'com.android.support:design:26.0.2'
     compile 'com.android.support:appcompat-v7:26.0.2'
     compile 'com.squareup.retrofit:retrofit:1.9.0'


### PR DESCRIPTION
https://www.twilio.com/docs/api/voice-sdk/android/changelog#204

#### 2.0.4
February 6, 2018

* Programmable Voice Android SDK 2.0.4 [[bintray]](https://bintray.com/twilio/releases/voice-android/2.0.4), [[docs]](https://media.twiliocdn.com/sdk/android/voice/releases/2.0.4/docs/)

#### Bug Fixes

- CLIENT-4321 Updated root certificate bundle included in the library.

#### Known issues

- CLIENT-2985 IPv6 is not supported.