### PR TITLE
Use 2.0.5

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
+    buildToolsVersion "27.0.3"
 
     defaultConfig {
         applicationId "com.twilio.voice.quickstart"
         minSdkVersion 16
-        targetSdkVersion 26
+        targetSdkVersion 27
         versionCode 1
         versionName "1.0"
     }
@@ -40,12 +40,12 @@ android {
 
 dependencies {
     testCompile 'junit:junit:4.12'
-    compile 'com.twilio:voice-android:2.0.4'
-    compile 'com.android.support:design:26.0.2'
-    compile 'com.android.support:appcompat-v7:26.0.2'
+    compile 'com.twilio:voice-android:2.0.5'
+    compile 'com.android.support:design:27.0.2'
+    compile 'com.android.support:appcompat-v7:27.0.2'
     compile 'com.squareup.retrofit:retrofit:1.9.0'
     compile 'com.koushikdutta.ion:ion:2.1.8'
-    compile 'com.google.firebase:firebase-messaging:10.0.1'
+    compile 'com.google.firebase:firebase-messaging:10.2.1'
 }
 
 apply plugin: 'com.google.gms.google-services'


### PR DESCRIPTION
https://www.twilio.com/docs/api/voice-sdk/android/changelog#205

#### 2.0.5

March 23, 2018

* Programmable Voice Android SDK 2.0.5 [[bintray]](https://bintray.com/twilio/releases/voice-android/2.0.5), [[docs]](https://media.twiliocdn.com/sdk/android/voice/releases/2.0.5/docs/)

#### Enhancements
- CLIENT-4350 Upgraded the library compileSDKVersion and targetSDKVersion to 27.

#### Bug Fixes

- CLIENT-4362 Increased the max teardown timeout from 1 second to 7 seconds. The max teardown timeout ensures that the Call is destroyed within a reasonable period of time for cases where a network condition prevents sending or receiving a disconnect message successfully to or from the Twilio infrastructure. Increasing the timeout ensures that in almost all cases the disconnect message will reach Twilio infrastructure and the Call will not be destroyed prematurely. It also guarantees a local cleanup in case disconnect messages fails to reach the app.

#### Known issues

- CLIENT-2985 IPv6 is not supported.