### PR TITLE
Use 2.0.6

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,7 +40,7 @@ android {
 
 dependencies {
     testCompile 'junit:junit:4.12'
-    compile 'com.twilio:voice-android:2.0.5'
+    compile 'com.twilio:voice-android:2.0.6'
     compile 'com.android.support:design:27.0.2'
     compile 'com.android.support:appcompat-v7:27.0.2'
     compile 'com.squareup.retrofit:retrofit:1.9.0'


### PR DESCRIPTION
https://www.twilio.com/docs/api/voice-sdk/android/changelog#206

#### 2.0.6

April 19, 2018

* Programmable Voice Android SDK 2.0.6 [[bintray]](https://bintray.com/twilio/releases/voice-android/2.0.6), [[docs]](https://media.twiliocdn.com/sdk/android/voice/releases/2.0.6/docs/)

#### Bug Fixes

- CLIENT-4574 Fixed compatibility issue with Twilio Chat related to overlapping raw resources used to perform certificate validation. This can result in `java.security.cert.CertPathValidatorException: Trust anchor for certification path not found.` when both Android Voice 2.0.5 or below is used with Android Chat 1.0.14 or above, 2.0.7 or above, and 3.0.0 or above.

#### Known issues

- CLIENT-2985 IPv6 is not supported.