### PR TITLE
Use 2.0.7

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,7 +40,7 @@ android {
 
 dependencies {
     testCompile 'junit:junit:4.12'
-    compile 'com.twilio:voice-android:2.0.6'
+    compile 'com.twilio:voice-android:2.0.7'
     compile 'com.android.support:design:27.0.2'
     compile 'com.android.support:appcompat-v7:27.0.2'
     compile 'com.squareup.retrofit:retrofit:1.9.0'


### PR DESCRIPTION
https://www.twilio.com/docs/api/voice-sdk/android/changelog#207

#### 2.0.7

May 07, 2018

* Programmable Voice Android SDK 2.0.7 [[bintray]](https://bintray.com/twilio/releases/voice-android/2.0.7), [[docs]](https://media.twiliocdn.com/sdk/android/voice/releases/2.0.7/docs/)

#### Bug Fixes

- CLIENT-4607 Fix issue where the Caller is prematurely disconnected while the Callee does not accept the call.

#### Known issues

- CLIENT-2985 IPv6 is not supported.
