### PR TITLE
CLIENT-4717 : Fixed a crash when starting activity from service on some Android versions. Fixed play ringing behavior when activity is restarted after getting destroyed. 

### DIFF
--- a/app/src/main/java/com/twilio/voice/quickstart/SoundPoolManager.java
+++ b/app/src/main/java/com/twilio/voice/quickstart/SoundPoolManager.java
@@ -11,6 +11,7 @@ public class SoundPoolManager {
 
     private boolean playing = false;
     private boolean loaded = false;
+    private boolean playingCalled = false;
     private float actualVolume;
     private float maxVolume;
     private float volume;
@@ -42,6 +43,10 @@ public class SoundPoolManager {
             @Override
             public void onLoadComplete(SoundPool soundPool, int sampleId, int status) {
                 loaded = true;
+                if (playingCalled) {
+                    playRinging();
+                    playingCalled = false;
+                }
             }
 
         });
@@ -60,6 +65,8 @@ public class SoundPoolManager {
         if (loaded && !playing) {
             ringingStreamId = soundPool.play(ringingSoundId, volume, volume, 1, -1, 1f);
             playing = true;
+        } else {
+            playingCalled = true;
         }
     }
 

--- a/app/src/main/java/com/twilio/voice/quickstart/fcm/VoiceFirebaseMessagingService.java
+++ b/app/src/main/java/com/twilio/voice/quickstart/fcm/VoiceFirebaseMessagingService.java
@@ -165,9 +165,9 @@ public class VoiceFirebaseMessagingService extends FirebaseMessagingService {
     /**
      * Build a notification.
      *
-     * @param text the text of the notification
+     * @param text          the text of the notification
      * @param pendingIntent the body, pending intent for the notification
-     * @param extras extras passed with the notification
+     * @param extras        extras passed with the notification
      * @return the builder
      */
     @TargetApi(Build.VERSION_CODES.O)

--- a/app/src/main/java/com/twilio/voice/quickstart/fcm/VoiceFirebaseMessagingService.java
+++ b/app/src/main/java/com/twilio/voice/quickstart/fcm/VoiceFirebaseMessagingService.java
@@ -158,6 +158,7 @@ public class VoiceFirebaseMessagingService extends FirebaseMessagingService {
         intent.putExtra(VoiceActivity.INCOMING_CALL_NOTIFICATION_ID, notificationId);
         intent.putExtra(VoiceActivity.INCOMING_CALL_INVITE, callInvite);
         intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         this.startActivity(intent);
     }
 


### PR DESCRIPTION
### Bug Fix  
- Fixed a crash on some Android versions when receiving a call and VoiceFirebaseMessagingService failed to start VoiceActivity.
- Fixed an issue when ringing sound was not playing when activity restarted. If `SoundPool` is not completed loading the resources, the `playRinging()` could not play the ringing. Added a flag to keep track of if  `playRinging()` was called before `onLoadComplete()`. If the flag is set, the code now calls `playRinging()` right after the files are loaded.

These issues were filed by @ellipsisx. Thank you.

https://github.com/twilio/voice-quickstart-android/issues/175 
https://github.com/twilio/voice-quickstart-android/issues/177 