### PR TITLE
Use 2.0.8

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,7 +40,7 @@ android {
 
 dependencies {
     testCompile 'junit:junit:4.12'
-    compile 'com.twilio:voice-android:2.0.7'
+    compile 'com.twilio:voice-android:2.0.8'
     compile 'com.android.support:design:27.0.2'
     compile 'com.android.support:appcompat-v7:27.0.2'
     compile 'com.squareup.retrofit:retrofit:1.9.0'


### PR DESCRIPTION
https://www.twilio.com/docs/api/voice-sdk/android/changelog#208

#### 2.0.8

July 12, 2018

* Programmable Voice Android SDK 2.0.8 [[bintray]](https://bintray.com/twilio/releases/voice-android/2.0.8), [[docs]](https://media.twiliocdn.com/sdk/android/voice/releases/2.0.8/docs/)

#### Bug Fixes

- CLIENT-4823 Fix an issue where early hangup did not disconnect the call if answerOnBridge is enabled.

#### Known issues

- CLIENT-2985 IPv6 is not supported.
