### PR TITLE
Use 3.0.0-preview1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Twilio Voice Quickstart for Android
 
-> **Deprecation Notice - Versions prior to 2.0.4**
->
-> Please note that **older versions of the Programmable Voice Android library prior to 2.0.4 are deprecated and will stop working on September 13, 2018**. Please make sure you’re using the latest version of the library in your apps, and make sure your customers update their apps by that date. For more information please review the following knowledge base [article](https://support.twilio.com/hc/en-us/articles/360002897814-Legacy-Twilio-Programmable-Voice-SDKs-impacted-by-SSL-certificate-deprecation).
+> This is a developer preview release of the Programmable Voice 3.X SDK for Android. This major version now uses WebRTC and is still under active development. APIs are subject to change and we recommend you look at known issues provided in the [changelog](https://www.twilio.com/docs/voice/voip-sdk/android/changelog). To use a generally available version of the Programmable Voice SDKs for Android, please see the master branch based on the 2.X APIs.
 
 Get started with Voice on Android:
 
@@ -245,7 +243,7 @@ You can find more documentation on getting started as well as our latest Javadoc
 
 
 * [Getting Started](https://www.twilio.com/docs/api/voice-sdk/android/getting-started)
-* [Javadoc](https://media.twiliocdn.com/sdk/android/voice/latest/docs/)
+* [Javadoc](https://media.twiliocdn.com/sdk/android/voice/3.0.0-preview1/docs/)
 
 ## Twilio Helper Libraries
 

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ You can find more documentation on getting started as well as our latest Javadoc
 
 
 * [Getting Started](https://www.twilio.com/docs/api/voice-sdk/android/getting-started)
-* [Javadoc](https://media.twiliocdn.com/sdk/android/voice/3.0.0-preview1/docs/)
+* [Javadoc](https://media.twiliocdn.com/sdk/android/voice/releases/3.0.0-preview1/docs/)
 
 ## Twilio Helper Libraries
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,7 +40,7 @@ android {
 
 dependencies {
     testCompile 'junit:junit:4.12'
-    compile 'com.twilio:voice-android:2.0.8'
+    compile 'com.twilio:voice-android:3.0.0-preview1'
     compile 'com.android.support:design:27.0.2'
     compile 'com.android.support:appcompat-v7:27.0.2'
     compile 'com.squareup.retrofit:retrofit:1.9.0'

--- a/app/src/main/java/com/twilio/voice/quickstart/VoiceActivity.java
+++ b/app/src/main/java/com/twilio/voice/quickstart/VoiceActivity.java
@@ -37,7 +37,6 @@ import android.widget.EditText;
 import com.google.firebase.iid.FirebaseInstanceId;
 import com.koushikdutta.async.future.FutureCallback;
 import com.koushikdutta.ion.Ion;
-import com.twilio.voice.AcceptOptions;
 import com.twilio.voice.Call;
 import com.twilio.voice.CallException;
 import com.twilio.voice.CallInvite;

--- a/app/src/main/java/com/twilio/voice/quickstart/VoiceActivity.java
+++ b/app/src/main/java/com/twilio/voice/quickstart/VoiceActivity.java
@@ -74,7 +74,7 @@ public class VoiceActivity extends AppCompatActivity {
     private VoiceBroadcastReceiver voiceBroadcastReceiver;
 
     // Empty HashMap, never populated for the Quickstart
-    HashMap<String, String> twiMLParams = new HashMap<>();
+    HashMap<String, String> params = new HashMap<>();
 
     private CoordinatorLayout coordinatorLayout;
     private FloatingActionButton callActionFab;
@@ -333,9 +333,9 @@ public class VoiceActivity extends AppCompatActivity {
             public void onClick(DialogInterface dialog, int which) {
                 // Place a call
                 EditText contact = (EditText) ((AlertDialog) dialog).findViewById(R.id.contact);
-                twiMLParams.put("to", contact.getText().toString());
+                params.put("to", contact.getText().toString());
                 ConnectOptions connectOptions = new ConnectOptions.Builder(accessToken)
-                        .params(twiMLParams)
+                        .params(params)
                         .build();
                 activeCall = Voice.connect(VoiceActivity.this, connectOptions, callListener);
                 setCallUI();
@@ -426,7 +426,7 @@ public class VoiceActivity extends AppCompatActivity {
      * Accept an incoming Call
      */
     private void answer() {
-        activeCallInvite.accept(this, new AcceptOptions.Builder().build(), callListener);
+        activeCallInvite.accept(this, callListener);
         notificationManager.cancel(activeCallNotificationId);
     }
 

--- a/app/src/main/java/com/twilio/voice/quickstart/VoiceActivity.java
+++ b/app/src/main/java/com/twilio/voice/quickstart/VoiceActivity.java
@@ -37,9 +37,11 @@ import android.widget.EditText;
 import com.google.firebase.iid.FirebaseInstanceId;
 import com.koushikdutta.async.future.FutureCallback;
 import com.koushikdutta.ion.Ion;
+import com.twilio.voice.AcceptOptions;
 import com.twilio.voice.Call;
 import com.twilio.voice.CallException;
 import com.twilio.voice.CallInvite;
+import com.twilio.voice.ConnectOptions;
 import com.twilio.voice.RegistrationException;
 import com.twilio.voice.RegistrationListener;
 import com.twilio.voice.Voice;
@@ -332,7 +334,10 @@ public class VoiceActivity extends AppCompatActivity {
                 // Place a call
                 EditText contact = (EditText) ((AlertDialog) dialog).findViewById(R.id.contact);
                 twiMLParams.put("to", contact.getText().toString());
-                activeCall = Voice.call(VoiceActivity.this, accessToken, twiMLParams, callListener);
+                ConnectOptions connectOptions = new ConnectOptions.Builder(accessToken)
+                        .params(twiMLParams)
+                        .build();
+                activeCall = Voice.connect(VoiceActivity.this, connectOptions, callListener);
                 setCallUI();
                 alertDialog.dismiss();
             }
@@ -421,7 +426,7 @@ public class VoiceActivity extends AppCompatActivity {
      * Accept an incoming Call
      */
     private void answer() {
-        activeCallInvite.accept(this, callListener);
+        activeCallInvite.accept(this, new AcceptOptions.Builder().build(), callListener);
         notificationManager.cancel(activeCallNotificationId);
     }
 


### PR DESCRIPTION
https://www.twilio.com/docs/api/voice-sdk/android/changelog#300-preview1

#### 3.0.0-preview1

August 15th, 2018

* Programmable Voice Android SDK 3.0.0-preview1 [[bintray]](https://bintray.com/twilio/releases/voice-android/3.0.0-preview1), [[docs]](https://media.twiliocdn.com/sdk/android/voice/releases/3.0.0-preview1/docs/)

This is the first WebRTC based release using Chromium WebRTC 57.

This SDK introduces ConnectOptions and AcceptOptions to allow developers to make behaviorial changes associated with a Call.

This SDK allows multiple active Calls to be managed by the application.

#### Enhancements

- API Changes:
  - Migrated the enum `PJSIP` in `LogModule` to a more granular set of enums (`CORE`, `PLATFORM`, `SIGNALING` and `WEBRTC`)
   - Introduced `ConnectOptions` to allow developers to make behaviorial changes associated with the call
  - Migrated the API to make a Call from `Voice.call(...)` to `Voice.connect(...)`

```
// Making a call in 2.X
 Voice.call(context, accessToken, params, listener);
       
// Making a call in 3.X
ConnectOptions connectOptions = new ConnectOptions.Builder(accessToken)
		    .setParams(params)
                    .build();
Voice.connect(context, connectOptions, listener);

```
		
- Migrated the API to accept a `CallInvite` using `AcceptOptions`

```
// Accepting a call in 2.X
CallInvite.accept(context, listener);
       
// Accepting a call in 3.X
AcceptOptions acceptOptions = new AcceptOptions.Builder()
            .build();
CallInvite.accept(context, acceptOptions, listener);
```	
		
- Introduced call holding via `Call.hold(boolean)` feature
- Migrate `Voice.setRegion(String)` to `ConnectOptions.Builder.region(String)` and `AcceptOptions.Builder.region(String)`
- Migrate `Voice.getRegion()` to `ConnectOptions.getRegion()` and `AcceptOptions.getRegion()`

#### Known issues

- CLIENT-4943 Restrictive networks may fail unless ICE servers are provided via `ConnectOptions.Builder.iceOptions(...)` or `AcceptOptions.Builder.iceOptions(...)`. ICE servers can be obtained from [Twilio Network Travarsal Service](https://www.twilio.com/stun-turn).
- CLIENT-4805 The SDK size is significantly larger than 2.x. A reduced size will be introduced during the beta period.
- CLIENT-4998 Network handoff, and subsequent connection renegotiation is not supported.
- CLIENT-2985 IPv6 is not supported.
- CLIENT-4698 Params that are passed to your TwiML Application while making calls are not URL encoded
- CLIENT-4547 Insights is not published
- CLIENT-4672, CLIENT-4673 Error codes 20157 and 20151 report different message and explanation text than Voice 2.0 SDKs
- CLIENT-4537 PCMU is the only supported codec. We plan on adding support for Opus moving forward. [#117](https://github.com/twilio/voice-quickstart-objc/issues/117)