### PR TITLE
Use 3.0.0-preview2

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,7 +40,7 @@ android {
 
 dependencies {
     testCompile 'junit:junit:4.12'
-    compile 'com.twilio:voice-android:3.0.0-preview1'
+    compile 'com.twilio:voice-android:3.0.0-preview2'
     compile 'com.android.support:design:27.0.2'
     compile 'com.android.support:appcompat-v7:27.0.2'
     compile 'com.squareup.retrofit:retrofit:1.9.0'

--- a/app/src/main/java/com/twilio/voice/quickstart/VoiceActivity.java
+++ b/app/src/main/java/com/twilio/voice/quickstart/VoiceActivity.java
@@ -184,7 +184,19 @@ public class VoiceActivity extends AppCompatActivity {
 
     private Call.Listener callListener() {
         return new Call.Listener() {
-
+            /*
+             * This callback is emitted once before the Call.Listener.onConnected() callback when
+             * the callee is being alerted of a Call. The behavior of this callback is determined by
+             * the answerOnBridge flag provided in the Dial verb of your TwiML application
+             * associated with this client. If the answerOnBridge flag is false, which is the
+             * default, the Call.Listener.onConnected() callback will be emitted immediately after
+             * Call.Listener.onRinging(). If the answerOnBridge flag is true, this will cause the
+             * call to emit the onConnected callback only after the call is answered.
+             * See answeronbridge for more details on how to use it with the Dial TwiML verb. If the
+             * twiML response contains a Say verb, then the call will emit the
+             * Call.Listener.onConnected callback immediately after Call.Listener.onRinging() is
+             * raised, irrespective of the value of answerOnBridge being set to true or false
+             */
             @Override
             public void onRinging(Call call) {
                 Log.d(TAG, "Ringing");

--- a/app/src/main/java/com/twilio/voice/quickstart/VoiceActivity.java
+++ b/app/src/main/java/com/twilio/voice/quickstart/VoiceActivity.java
@@ -184,6 +184,12 @@ public class VoiceActivity extends AppCompatActivity {
 
     private Call.Listener callListener() {
         return new Call.Listener() {
+
+            @Override
+            public void onRinging(Call call) {
+                Log.d(TAG, "Ringing");
+            }
+
             @Override
             public void onConnectFailure(Call call, CallException error) {
                 setAudioFocus(false);


### PR DESCRIPTION
https://www.twilio.com/docs/voice/voip-sdk/android/changelog#300-preview2

#### 3.0.0-preview2

August 27th, 2018

* Programmable Voice Android SDK 3.0.0-preview2 [[bintray]](https://bintray.com/twilio/releases/voice-android/3.0.0-preview2), [[docs]](https://media.twiliocdn.com/sdk/android/voice/releases/3.0.0-preview2/docs/)

#### Enhancements

##### API Changes:

 - Introduced `CallState.RINGING`
 - Introduced a new callback method `Call.Listener.onRinging()`. This callback is emitted once before the `Call.Listener.onConnected()` callback when the callee is being alerted of a `Call`. The behavior of this callback is determined by the `answerOnBridge` flag provided in the `Dial` verb of your TwiML application associated with this client. If the `answerOnBridge` flag is `false`, which is the default, the `Call.Listener.onConnected()` callback will be emitted immediately after `Call.Listener.onRinging()`. If the `answerOnBridge` flag is `true`, this will cause the call to emit the `onConnected` callback only after the call is answered. See [answeronbridge](https://www.twilio.com/docs/voice/twiml/dial#answeronbridge) for more details on how to use it with the `Dial` TwiML verb. If the twiML response contains a `Say` verb, then the call will emit the `Call.Listener.onConnected` callback immediately after `Call.Listener.onRinging()` is raised, irrespective of the value of `answerOnBridge` being set to `true` or `false`