### PR TITLE
Use preview3.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,7 +40,7 @@ android {
 
 dependencies {
     testCompile 'junit:junit:4.12'
-    compile 'com.twilio:voice-android:3.0.0-preview2'
+    compile 'com.twilio:voice-android:3.0.0-preview3'
     compile 'com.android.support:design:27.0.2'
     compile 'com.android.support:appcompat-v7:27.0.2'
     compile 'com.squareup.retrofit:retrofit:1.9.0'

--- a/app/src/main/java/com/twilio/voice/quickstart/VoiceActivity.java
+++ b/app/src/main/java/com/twilio/voice/quickstart/VoiceActivity.java
@@ -83,8 +83,10 @@ public class VoiceActivity extends AppCompatActivity {
     private SoundPoolManager soundPoolManager;
 
     public static final String INCOMING_CALL_INVITE = "INCOMING_CALL_INVITE";
+    public static final String CANCELLED_CALL_INVITE = "CANCELLED_CALL_INVITE";
     public static final String INCOMING_CALL_NOTIFICATION_ID = "INCOMING_CALL_NOTIFICATION_ID";
     public static final String ACTION_INCOMING_CALL = "ACTION_INCOMING_CALL";
+    public static final String ACTION_CANCEL_CALL = "ACTION_CANCEL_CALL";
     public static final String ACTION_FCM_TOKEN = "ACTION_FCM_TOKEN";
 
     private NotificationManager notificationManager;
@@ -279,7 +281,7 @@ public class VoiceActivity extends AppCompatActivity {
         if (intent != null && intent.getAction() != null) {
             if (intent.getAction().equals(ACTION_INCOMING_CALL)) {
                 activeCallInvite = intent.getParcelableExtra(INCOMING_CALL_INVITE);
-                if (activeCallInvite != null && (activeCallInvite.getState() == CallInvite.State.PENDING)) {
+                if (activeCallInvite != null) {
                     soundPoolManager.playRinging();
                     alertDialog = createIncomingCallDialog(VoiceActivity.this,
                             activeCallInvite,
@@ -288,10 +290,12 @@ public class VoiceActivity extends AppCompatActivity {
                     alertDialog.show();
                     activeCallNotificationId = intent.getIntExtra(INCOMING_CALL_NOTIFICATION_ID, 0);
                 } else {
-                    if (alertDialog != null && alertDialog.isShowing()) {
-                        soundPoolManager.stopRinging();
-                        alertDialog.cancel();
-                    }
+
+                }
+            } else if (intent.getAction().equals(ACTION_CANCEL_CALL)) {
+                if (alertDialog != null && alertDialog.isShowing()) {
+                    soundPoolManager.stopRinging();
+                    alertDialog.cancel();
                 }
             } else if (intent.getAction().equals(ACTION_FCM_TOKEN)) {
                 retrieveAccessToken();
@@ -303,6 +307,7 @@ public class VoiceActivity extends AppCompatActivity {
         if (!isReceiverRegistered) {
             IntentFilter intentFilter = new IntentFilter();
             intentFilter.addAction(ACTION_INCOMING_CALL);
+            intentFilter.addAction(ACTION_CANCEL_CALL);
             intentFilter.addAction(ACTION_FCM_TOKEN);
             LocalBroadcastManager.getInstance(this).registerReceiver(
                     voiceBroadcastReceiver, intentFilter);
@@ -322,9 +327,9 @@ public class VoiceActivity extends AppCompatActivity {
         @Override
         public void onReceive(Context context, Intent intent) {
             String action = intent.getAction();
-            if (action.equals(ACTION_INCOMING_CALL)) {
+            if (action.equals(ACTION_INCOMING_CALL) || action.equals(ACTION_CANCEL_CALL)) {
                 /*
-                 * Handle the incoming call invite
+                 * Handle the incoming or cancelled call invite
                  */
                 handleIncomingCallIntent(intent);
             }

--- a/app/src/main/java/com/twilio/voice/quickstart/fcm/VoiceFirebaseMessagingService.java
+++ b/app/src/main/java/com/twilio/voice/quickstart/fcm/VoiceFirebaseMessagingService.java
@@ -11,13 +11,15 @@ import android.graphics.Color;
 import android.os.Build;
 import android.os.Bundle;
 import android.service.notification.StatusBarNotification;
+import android.support.annotation.NonNull;
 import android.support.v4.app.NotificationCompat;
+import android.support.v4.content.LocalBroadcastManager;
 import android.util.Log;
 
 import com.google.firebase.messaging.FirebaseMessagingService;
 import com.google.firebase.messaging.RemoteMessage;
 import com.twilio.voice.CallInvite;
-import com.twilio.voice.MessageException;
+import com.twilio.voice.CancelledCallInvite;
 import com.twilio.voice.MessageListener;
 import com.twilio.voice.Voice;
 import com.twilio.voice.quickstart.R;
@@ -56,96 +58,106 @@ public class VoiceFirebaseMessagingService extends FirebaseMessagingService {
         if (remoteMessage.getData().size() > 0) {
             Map<String, String> data = remoteMessage.getData();
             final int notificationId = (int) System.currentTimeMillis();
-            Voice.handleMessage(this, data, new MessageListener() {
+
+            boolean valid = Voice.handleMessage(this, remoteMessage.getData(), new MessageListener() {
                 @Override
-                public void onCallInvite(CallInvite callInvite) {
+                public void onCallInvite(@NonNull CallInvite callInvite) {
+                    final int notificationId = (int) System.currentTimeMillis();
                     VoiceFirebaseMessagingService.this.notify(callInvite, notificationId);
                     VoiceFirebaseMessagingService.this.sendCallInviteToActivity(callInvite, notificationId);
                 }
 
                 @Override
-                public void onError(MessageException messageException) {
-                    Log.e(TAG, messageException.getLocalizedMessage());
+                public void onCancelledCallInvite(@NonNull CancelledCallInvite cancelledCallInvite) {
+                    VoiceFirebaseMessagingService.this.cancelNotification(cancelledCallInvite);
+                    VoiceFirebaseMessagingService.this.sendCancelledCallInviteToActivity(
+                            cancelledCallInvite);
                 }
+
             });
+
+            if (!valid) {
+                Log.e(TAG, "The message was not a valid Twilio Voice SDK payload: " +
+                        remoteMessage.getData());
+            }
+
         }
     }
 
     private void notify(CallInvite callInvite, int notificationId) {
-        String callSid = callInvite.getCallSid();
-        Notification notification = null;
+        Intent intent = new Intent(this, VoiceActivity.class);
+        intent.setAction(VoiceActivity.ACTION_INCOMING_CALL);
+        intent.putExtra(VoiceActivity.INCOMING_CALL_NOTIFICATION_ID, notificationId);
+        intent.putExtra(VoiceActivity.INCOMING_CALL_INVITE, callInvite);
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        PendingIntent pendingIntent =
+                PendingIntent.getActivity(this, notificationId, intent, PendingIntent.FLAG_CANCEL_CURRENT);
+        /*
+         * Pass the notification id and call sid to use as an identifier to cancel the
+         * notification later
+         */
+        Bundle extras = new Bundle();
+        extras.putInt(NOTIFICATION_ID_KEY, notificationId);
+        extras.putString(CALL_SID_KEY, callInvite.getCallSid());
 
-        if (callInvite.getState() == CallInvite.State.PENDING) {
-            Intent intent = new Intent(this, VoiceActivity.class);
-            intent.setAction(VoiceActivity.ACTION_INCOMING_CALL);
-            intent.putExtra(VoiceActivity.INCOMING_CALL_NOTIFICATION_ID, notificationId);
-            intent.putExtra(VoiceActivity.INCOMING_CALL_INVITE, callInvite);
-            intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
-            PendingIntent pendingIntent =
-                    PendingIntent.getActivity(this, notificationId, intent, PendingIntent.FLAG_ONE_SHOT);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            NotificationChannel callInviteChannel = new NotificationChannel(VOICE_CHANNEL,
+                    "Primary Voice Channel", NotificationManager.IMPORTANCE_DEFAULT);
+            callInviteChannel.setLightColor(Color.GREEN);
+            callInviteChannel.setLockscreenVisibility(Notification.VISIBILITY_PRIVATE);
+            notificationManager.createNotificationChannel(callInviteChannel);
+
+            Notification notification =
+                    buildNotification(callInvite.getFrom() + " is calling.",
+                            pendingIntent,
+                            extras);
+            notificationManager.notify(notificationId, notification);
+        } else {
+            NotificationCompat.Builder notificationBuilder =
+                    new NotificationCompat.Builder(this)
+                            .setSmallIcon(R.drawable.ic_call_end_white_24dp)
+                            .setContentTitle(getString(R.string.app_name))
+                            .setContentText(callInvite.getFrom() + " is calling.")
+                            .setAutoCancel(true)
+                            .setExtras(extras)
+                            .setContentIntent(pendingIntent)
+                            .setGroup("test_app_notification")
+                            .setColor(Color.rgb(214, 10, 37));
+
+            notificationManager.notify(notificationId, notificationBuilder.build());
+        }
+    }
+
+    private void cancelNotification(CancelledCallInvite cancelledCallInvite) {
+        SoundPoolManager.getInstance((this)).stopRinging();
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
             /*
-             * Pass the notification id and call sid to use as an identifier to cancel the
-             * notification later
+             * If the incoming call was cancelled then remove the notification by matching
+             * it with the call sid from the list of notifications in the notification drawer.
              */
-            Bundle extras = new Bundle();
-            extras.putInt(NOTIFICATION_ID_KEY, notificationId);
-            extras.putString(CALL_SID_KEY, callSid);
+            StatusBarNotification[] activeNotifications =
+                    notificationManager.getActiveNotifications();
+            for (StatusBarNotification statusBarNotification : activeNotifications) {
+                Notification notification = statusBarNotification.getNotification();
+                Bundle extras = notification.extras;
+                String notificationCallSid = extras.getString(CALL_SID_KEY);
 
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                NotificationChannel callInviteChannel = new NotificationChannel(VOICE_CHANNEL,
-                        "Primary Voice Channel", NotificationManager.IMPORTANCE_DEFAULT);
-                callInviteChannel.setLightColor(Color.GREEN);
-                callInviteChannel.setLockscreenVisibility(Notification.VISIBILITY_PRIVATE);
-                notificationManager.createNotificationChannel(callInviteChannel);
-
-                notification = buildNotification(callInvite.getFrom() + " is calling.", pendingIntent, extras);
-                notificationManager.notify(notificationId, notification);
-            } else {
-                NotificationCompat.Builder notificationBuilder =
-                        new NotificationCompat.Builder(this)
-                                .setSmallIcon(R.drawable.ic_call_end_white_24dp)
-                                .setContentTitle(getString(R.string.app_name))
-                                .setContentText(callInvite.getFrom() + " is calling.")
-                                .setAutoCancel(true)
-                                .setExtras(extras)
-                                .setContentIntent(pendingIntent)
-                                .setGroup("test_app_notification")
-                                .setColor(Color.rgb(214, 10, 37));
-
-                notificationManager.notify(notificationId, notificationBuilder.build());
+                if (cancelledCallInvite.getCallSid().equals(notificationCallSid)) {
+                    notificationManager.cancel(extras.getInt(NOTIFICATION_ID_KEY));
+                }
             }
         } else {
-            SoundPoolManager.getInstance(this).stopRinging();
-            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
-                /*
-                 * If the incoming call was cancelled then remove the notification by matching
-                 * it with the call sid from the list of notifications in the notification drawer.
-                 */
-                StatusBarNotification[] activeNotifications = notificationManager.getActiveNotifications();
-                for (StatusBarNotification statusBarNotification : activeNotifications) {
-                    notification = statusBarNotification.getNotification();
-                    Bundle extras = notification.extras;
-                    String notificationCallSid = extras.getString(CALL_SID_KEY);
-
-                    if (callSid.equals(notificationCallSid)) {
-                        notificationManager.cancel(extras.getInt(NOTIFICATION_ID_KEY));
-                    } else {
-                        sendCallInviteToActivity(callInvite, notificationId);
-                    }
-                }
-            } else {
-                /*
-                 * Prior to Android M the notification manager did not provide a list of
-                 * active notifications so we lazily clear all the notifications when
-                 * receiving a cancelled call.
-                 *
-                 * In order to properly cancel a notification using
-                 * NotificationManager.cancel(notificationId) we should store the call sid &
-                 * notification id of any incoming calls using shared preferences or some other form
-                 * of persistent storage.
-                 */
-                notificationManager.cancelAll();
-            }
+            /*
+             * Prior to Android M the notification manager did not provide a list of
+             * active notifications so we lazily clear all the notifications when
+             * receiving a CancelledCallInvite.
+             *
+             * In order to properly cancel a notification using
+             * NotificationManager.cancel(notificationId) we should store the call sid &
+             * notification id of any incoming calls using shared preferences or some other form
+             * of persistent storage.
+             */
+            notificationManager.cancelAll();
         }
     }
 
@@ -160,6 +172,15 @@ public class VoiceFirebaseMessagingService extends FirebaseMessagingService {
         intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         this.startActivity(intent);
+    }
+
+    /*
+     * Send the CancelledCallInvite to the VoiceActivity
+     */
+    private void sendCancelledCallInviteToActivity(CancelledCallInvite cancelledCallInvite) {
+        Intent intent = new Intent(VoiceActivity.ACTION_CANCEL_CALL);
+        intent.putExtra(VoiceActivity.CANCELLED_CALL_INVITE, cancelledCallInvite);
+        LocalBroadcastManager.getInstance(this).sendBroadcast(intent);
     }
 
     /**


### PR DESCRIPTION
https://www.twilio.com/docs/voice/voip-sdk/android/changelog#300-preview3

#### 3.0.0-preview3

* Programmable Voice Android SDK 3.0.0-preview3 [[bintray]](https://bintray.com/twilio/releases/voice-android/3.0.0-preview3), [[docs]](https://media.twiliocdn.com/sdk/android/voice/releases/3.0.0-preview3/docs/)

#### Enhancements

##### API Changes:

 - Nullability annotations have been added. Methods that expect `@NonNull` parameters throw `NullPointerException`. Methods that validate parameters for a specified input throw `IllegalStateException` if invalid.
 - Moved `CallState` to `Call.State`
 - Provide a stateless mechanism for processing push messages related to call invites and call invite cancellations. This API no longer raises errors when processing invalid messages, instead a `boolean` value is returned when `handleMessage(context, data)` is called. The boolean value is `true` when the provided data results in a `CallInvite` or `CancelledCallInvite`. If `handleMessage(context, data)` returns `false` it means the data provided was not a Twilio Voice push message. The `CallInvite` has an `accept()` and `reject()` method. While the `CancelledCallInvite` simply provides the `to`, `from`, and `callSid` fields also available in the `CallInvite`. The method `getCallSid()` can be used to associate a `CallInvite` with a `CancelledCallInvite`.
   - Migrated the API `CallInvite` to `CallInvite` and `CancelledCallInvite`.

```
       // Processing push messages in 2.X
       handleMessage(context, data, new MessageListener() {
           @Override
           void onCallInvite(CallInvite callInvite) {
                 // Check state and process invite
                 if (callInvite.getState().equals(PENDING)) {
                     // Show notification to answer or reject call
                 } else if(callInvite.getState().equals(CANCELLED)) {
                     // Hide notification
                 }
           }

           @Override
           void onError(MessageException messageException) {
               // Invalid data was provided
           }
       });

       // Processing push messages in 3.X
       boolean handled = handleMessage(context, data, new MessageListener() {
           @Override
           void onCallInvite(CallInvite callInvite) {
               // Show notification to answer or reject call
           }

           @Override
           void onCancelledCallInvite(CancelledCallInvite callInvite) {
               // Hide notification
           }
       });

       if(!handled) {
           // This message is not a Twilio voice push message
       }
```
- Introduced `call.getStats()` method that returns a list of `StatsReport` with metrics for all the audio tracks in a call.
	
```
	call.getStats(new StatsListener() {
        @Override
        public void onStats(@NonNull List<StatsReport> statsReports) {
            // Process statsReports
        }
	});
```