### PR TITLE
Using 3.0.0-preview4.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,6 +4,11 @@ android {
     compileSdkVersion 27
     buildToolsVersion "27.0.3"
 
+    compileOptions {
+        sourceCompatibility 1.8
+        targetCompatibility 1.8
+    }
+
     defaultConfig {
         applicationId "com.twilio.voice.quickstart"
         minSdkVersion 16
@@ -39,13 +44,14 @@ android {
 }
 
 dependencies {
-    testCompile 'junit:junit:4.12'
-    compile 'com.twilio:voice-android:3.0.0-preview3'
-    compile 'com.android.support:design:27.0.2'
-    compile 'com.android.support:appcompat-v7:27.0.2'
-    compile 'com.squareup.retrofit:retrofit:1.9.0'
-    compile 'com.koushikdutta.ion:ion:2.1.8'
-    compile 'com.google.firebase:firebase-messaging:10.2.1'
+    testImplementation 'junit:junit:4.12'
+
+    implementation 'com.twilio:voice-android:3.0.0-preview4'
+    implementation 'com.android.support:design:27.0.2'
+    implementation 'com.android.support:appcompat-v7:27.0.2'
+    implementation 'com.squareup.retrofit:retrofit:1.9.0'
+    implementation 'com.koushikdutta.ion:ion:2.1.8'
+    implementation 'com.google.firebase:firebase-messaging:11.0.4'
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/build.gradle
+++ b/build.gradle
@@ -3,10 +3,15 @@
 buildscript {
     repositories {
         jcenter()
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0'
-        classpath 'com.google.gms:google-services:3.0.0'
+        classpath 'com.android.tools.build:gradle:3.1.3'
+        classpath 'com.google.gms:google-services:3.2.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -15,9 +20,12 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         jcenter()
+        mavenCentral()
         maven {
-            url "https://maven.google.com"
+            url 'https://maven.google.com/'
+            name 'Google'
         }
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Apr 13 15:01:57 EDT 2017
+#Fri Sep 28 15:41:43 PDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip


### PR DESCRIPTION
https://www.twilio.com/docs/voice/voip-sdk/android/3x-changelog#300-preview4

## 3.0.0-preview4

* Programmable Voice Android SDK 3.0.0-preview4 [[bintray]](https://bintray.com/twilio/releases/voice-android/3.0.0-preview4), [[docs]](https://media.twiliocdn.com/sdk/android/voice/releases/3.0.0-preview4/docs/)

### Enhancements

- Upgraded to WebRTC 67
- Upgraded to Java 8. Add the following snippet to your `build.gradle` to enable Java 8 features required to build the 3.x Voice Android SDK:

    ```Groovy
        android {
            compileOptions {
                sourceCompatibility 1.8
                targetCompatibility 1.8
            }
        }
    ```
- Report registration and unregistration events to Twilio Insights.    

### Library Size Report

| ABI             | APK Size Impact |
| --------------- | --------------- |
| universal       | 18.1MB          |
| armeabi-v7a     | 4.1MB           |
| arm64-v8a       | 4.7MB           |
| x86             | 5MB             |
| x86_64          | 5MB             |