### PR TITLE
Use preview6.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,7 +46,7 @@ android {
 dependencies {
     testImplementation 'junit:junit:4.12'
 
-    implementation 'com.twilio:voice-android:3.0.0-preview5'
+    implementation 'com.twilio:voice-android:3.0.0-preview6'
     implementation 'com.android.support:design:27.0.2'
     implementation 'com.android.support:appcompat-v7:27.0.2'
     implementation 'com.squareup.retrofit:retrofit:1.9.0'


### PR DESCRIPTION
https://www.twilio.com/docs/voice/voip-sdk/android/3x-changelog#300-preview6

### 3.0.0-preview6

* Programmable Voice Android SDK 3.0.0-preview6 [[bintray]](https://bintray.com/twilio/releases/voice-android/3.0.0-preview6), [[docs]](https://media.twiliocdn.com/sdk/android/voice/releases/3.0.0-preview6/docs/)

#### Enhancements

- The Android Voice SDK is built with an audio only variant of WebRTC 67. The table below shows the size reduction from compiling with an audio only variant release:


    | ABI             | 3.0.0-preview5 APK Size Impact | 3.0.0-preview6 APK Size Impact |
    | --------------- | --------------- | --------------- |
    | universal       | 17.8MB          | 15.1MB          |
    | armeabi-v7a     | 4MB             | 3.4MB           |
    | arm64-v8a       | 4.6MB           | 3.9MB           |
    | x86             | 4.9MB           | 4MB             |
    | x86_64          | 4.9MB           | 4.1MB           |

#### Library Size Report

| ABI             | APK Size Impact |
| --------------- | --------------- |
| universal       | 15.1MB          |
| armeabi-v7a     | 3.4MB             |
| arm64-v8a       | 3.9MB           |
| x86             | 4MB           |
| x86_64          | 4.1MB           |