### PR TITLE
Use 3.0.0-beta1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Twilio Voice Quickstart for Android
 
-> This is a developer preview release of the Programmable Voice 3.X SDK for Android. This major version now uses WebRTC and is still under active development. APIs are subject to change and we recommend you look at known issues provided in the [changelog](https://www.twilio.com/docs/voice/voip-sdk/android/changelog). To use a generally available version of the Programmable Voice SDKs for Android, please see the master branch based on the 2.X APIs.
+> This is a beta release of the Programmable Voice 3.X SDK for Android. This major version now uses WebRTC. APIs are unlikely to change. We recommend you look at known issues provided in the changelog. To use a generally available version of the Programmable Voice SDKs for Android, please see the master branch based on the 2.X APIs.
 
 Get started with Voice on Android:
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,7 +46,7 @@ android {
 dependencies {
     testImplementation 'junit:junit:4.12'
 
-    implementation 'com.twilio:voice-android:3.0.0-preview6'
+    implementation 'com.twilio:voice-android:3.0.0-beta1'
     implementation 'com.android.support:design:27.0.2'
     implementation 'com.android.support:appcompat-v7:27.0.2'
     implementation 'com.squareup.retrofit:retrofit:1.9.0'


### PR DESCRIPTION
https://www.twilio.com/docs/voice/voip-sdk/android/3x-changelog#300-beta1

### 3.0.0-beta1

November 24th, 2018

* Programmable Voice Android SDK 3.0.0-beta1 [[bintray]](https://bintray.com/twilio/releases/voice-android/3.0.0-beta1), [[docs]](https://media.twiliocdn.com/sdk/android/voice/releases/3.0.0-beta1/docs/)

#### Enhancements

- Documented the default log level `LogLevel.ERROR` in `getLogLevel` and `getLogModuleLevel`
javadoc.
- Added media and signaling related error codes.

#### Library Size Report

| ABI             | APK Size Impact |
| --------------- | --------------- |
| universal       | 15.1MB          |
| armeabi-v7a     | 3.4MB           |
| arm64-v8a       | 3.9MB           |
| x86             | 4MB             |
| x86_64          | 4.1MB           |

#### Known issues

- CLIENT-5075 The SDK cannot be added alongside the Programmable Video SDK.
- CLIENT-5062 Calls made to a client or PSTN number that have a long duration before answering may not get connected.
- CLIENT-4943 Restrictive networks may fail unless ICE servers are provided via `ConnectOptions.Builder.iceOptions(...)` or `AcceptOptions.Builder.iceOptions(...)`. ICE servers can be obtained from [Twilio Network Travarsal Service](https://www.twilio.com/stun-turn).
- CLIENT-4805 The SDK size is significantly larger than 2.x. A reduced size will be introduced during the beta period.
- CLIENT-4998 Network handoff, and subsequent connection renegotiation is not supported.
- CLIENT-2985 IPv6 is not supported.
- CLIENT-4673 Error codes 20151 report different message and explanation text than Voice 2.0 SDKs
- CLIENT-4537 PCMU is the only supported codec. We plan on adding support for Opus moving forward. [#117](https://github.com/twilio/voice-quickstart-objc/issues/117)
- CLIENT-5242 Occasional native crash in `AsyncTask` of registration/unregistration and event publishing. The crash has only been observed on API 18 devices and results from a thread [safety bug in Android](https://issuetracker.google.com/issues/37002161). Similar crashes have been reported in the popular networking library OkHttp [#1520](https://github.com/square/okhttp/issues/1520) [#1338](https://github.com/square/okhttp/issues/1338). If this bug is impacting your applications, please open an issue on [our quickstart](https://github.com/twilio/voice-quickstart-android) and we will investigate potential fixes.
- CLIENT-5398 Unmuting a call on hold causes audio to flow.