### PR TITLE
Use Voice SDK 3.0.0-beta2

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Voice Android 3.X has a number of new features listed below:
 3. [Hold](#feature3)
 4. [Ringing](#feature4)
 5. [Stats](#feature5)
+6. [Preferred Audio Codec](#feature6)
 
 #### <a name="feature1"></a>WebRTC
 
@@ -249,6 +250,18 @@ public class Call {
 #### <a name="feature5"></a>Stats
 
 Statistics related to the media in the call can now be retrieved by calling `Call.getStats(StatsListener listener)`. The `StatsListener` returns a `StatsReport` that provides statistics about the local and remote audio in the call.
+
+#### <a name="feature6"></a>Preferred Audio Codec
+
+In Voice Android 3.X, you can provide your preferred audio codecs in the `ConnectOptions` and the `AcceptOptions`. The only audio codec supported by our mobile infrastructure is currently PCMU. Opus is not currently available on our mobile infrastructure. However it will become available in Q1 of 2019. At that point the default audio codec for all 3.X mobile clients will be Opus. To always use PCMU as the negotiated audio codec instead you can add it as the first codec in the preferAudioCodecs list.
+
+```Java
+ ConnectOptions connectOptions = new ConnectOptions.Builder(accessToken)
+                        .params(params)
+                        .preferAudioCodecs(Arrays.asList(new OpusCodec(), new PcmuCodec()))
+                        .build();
+Call call = Voice.connect(VoiceActivity.this, connectOptions, callListener);
+```
 
 ## Migration Guide
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,7 +46,7 @@ android {
 dependencies {
     testImplementation 'junit:junit:4.12'
 
-    implementation 'com.twilio:voice-android:3.0.0-beta1'
+    implementation 'com.twilio:voice-android:3.0.0-beta2'
     implementation 'com.android.support:design:27.0.2'
     implementation 'com.android.support:appcompat-v7:27.0.2'
     implementation 'com.squareup.retrofit:retrofit:1.9.0'

--- a/app/src/main/java/com/twilio/voice/quickstart/VoiceActivity.java
+++ b/app/src/main/java/com/twilio/voice/quickstart/VoiceActivity.java
@@ -42,11 +42,16 @@ import com.twilio.voice.Call;
 import com.twilio.voice.CallException;
 import com.twilio.voice.CallInvite;
 import com.twilio.voice.ConnectOptions;
+import com.twilio.voice.OpusCodec;
+import com.twilio.voice.PcmuCodec;
 import com.twilio.voice.RegistrationException;
 import com.twilio.voice.RegistrationListener;
 import com.twilio.voice.Voice;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Map;
 
 public class VoiceActivity extends AppCompatActivity {
 
@@ -364,8 +369,10 @@ public class VoiceActivity extends AppCompatActivity {
                 // Place a call
                 EditText contact = (EditText) ((AlertDialog) dialog).findViewById(R.id.contact);
                 params.put("to", contact.getText().toString());
+
                 ConnectOptions connectOptions = new ConnectOptions.Builder(accessToken)
                         .params(params)
+                        .preferAudioCodecs(Arrays.asList(new OpusCodec(), new PcmuCodec()))
                         .build();
                 activeCall = Voice.connect(VoiceActivity.this, connectOptions, callListener);
                 setCallUI();

--- a/app/src/main/java/com/twilio/voice/quickstart/VoiceActivity.java
+++ b/app/src/main/java/com/twilio/voice/quickstart/VoiceActivity.java
@@ -48,10 +48,8 @@ import com.twilio.voice.RegistrationException;
 import com.twilio.voice.RegistrationListener;
 import com.twilio.voice.Voice;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.Map;
 
 public class VoiceActivity extends AppCompatActivity {
 

--- a/app/src/main/java/com/twilio/voice/quickstart/VoiceActivity.java
+++ b/app/src/main/java/com/twilio/voice/quickstart/VoiceActivity.java
@@ -42,13 +42,10 @@ import com.twilio.voice.Call;
 import com.twilio.voice.CallException;
 import com.twilio.voice.CallInvite;
 import com.twilio.voice.ConnectOptions;
-import com.twilio.voice.OpusCodec;
-import com.twilio.voice.PcmuCodec;
 import com.twilio.voice.RegistrationException;
 import com.twilio.voice.RegistrationListener;
 import com.twilio.voice.Voice;
 
-import java.util.Arrays;
 import java.util.HashMap;
 
 public class VoiceActivity extends AppCompatActivity {
@@ -367,10 +364,8 @@ public class VoiceActivity extends AppCompatActivity {
                 // Place a call
                 EditText contact = (EditText) ((AlertDialog) dialog).findViewById(R.id.contact);
                 params.put("to", contact.getText().toString());
-
                 ConnectOptions connectOptions = new ConnectOptions.Builder(accessToken)
                         .params(params)
-                        .preferAudioCodecs(Arrays.asList(new OpusCodec(), new PcmuCodec()))
                         .build();
                 activeCall = Voice.connect(VoiceActivity.this, connectOptions, callListener);
                 setCallUI();


### PR DESCRIPTION
https://www.twilio.com/docs/voice/voip-sdk/android/3x-changelog#300-beta2

### 3.0.0-beta2

December 12th, 2018

* Programmable Voice Android SDK 3.0.0-beta2 [[bintray]](https://bintray.com/twilio/releases/voice-android/3.0.0-beta2), [[docs]](https://media.twiliocdn.com/sdk/android/voice/releases/3.0.0-beta2/docs/)

#### Enhancements

- Added new error code 31008. This error is raised when a CallInvite is accepted after a call has ended.
- `ConnectOptions.Builder.preferAudioCodecs(...)` and `AcceptOptions.Builder.preferAudioCodecs(...)` were added to set preferred audio codecs.

#### Bug Fixes
- CLIENT-5398 Unmuting a call on hold causes audio to flow.

#### Library Size Report

| ABI             | APK Size Impact |
| --------------- | --------------- |
| universal       | 15.3MB          |
| armeabi-v7a     | 3.4MB           |
| arm64-v8a       | 3.9MB           |
| x86             | 4.1MB           |
| x86_64          | 4.1MB           |

#### Known issues

- CLIENT-5075 The SDK cannot be added alongside the Programmable Video SDK.
- CLIENT-4943 Restrictive networks may fail unless ICE servers are provided via `ConnectOptions.Builder.iceOptions(...)` or `AcceptOptions.Builder.iceOptions(...)`. ICE servers can be obtained from [Twilio Network Travarsal Service](https://www.twilio.com/stun-turn).
- CLIENT-4805 The SDK size is significantly larger than 2.x. A reduced size will be introduced during the beta period.
- CLIENT-4998 Network handoff, and subsequent connection renegotiation is not supported.
- CLIENT-2985 IPv6 is not supported.
- CLIENT-4673 Error codes 20151 report different message and explanation text than Voice 2.0 SDKs
- CLIENT-4537 PCMU is the only supported codec. We plan on adding support for Opus moving forward. [#117](https://github.com/twilio/voice-quickstart-objc/issues/117)
- CLIENT-5242 Occasional native crash in `AsyncTask` of registration/unregistration and event publishing. The crash has only been observed on API 18 devices and results from a thread [safety bug in Android](https://issuetracker.google.com/issues/37002161). Similar crashes have been reported in the popular networking library OkHttp [#1520](https://github.com/square/okhttp/issues/1520) [#1338](https://github.com/square/okhttp/issues/1338). If this bug is impacting your applications, please open an issue on [our quickstart](https://github.com/twilio/voice-quickstart-android) and we will investigate potential fixes.