### PR TITLE
Use Voice SDK 2.1.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,7 +40,7 @@ android {
 
 dependencies {
     testCompile 'junit:junit:4.12'
-    compile 'com.twilio:voice-android:2.0.9'
+    compile 'com.twilio:voice-android:2.1.0'
     compile 'com.android.support:design:27.0.2'
     compile 'com.android.support:appcompat-v7:27.0.2'
     compile 'com.squareup.retrofit:retrofit:1.9.0'


### PR DESCRIPTION
https://www.twilio.com/docs/voice/voip-sdk/android/changelog#210

### 2.1.0
February 5th, 2019

* Programmable Voice Android SDK 2.1.0 [[bintray]](https://bintray.com/twilio/releases/voice-android/2.1.0), [[docs]](https://media.twiliocdn.com/sdk/android/voice/releases/2.1.0/docs/)

#### Updates

- CLIENT-5596 Added `VoiceException.EXCEPTION_ACCESS_TOKEN_REJECTED`. This error is raised when attempting to authenticate with a token that is invalid.

#### Known issues

- CLIENT-2985 IPv6 is not supported.
- CLIENT-5242 Occasional native crash in `AsyncTask` of registration/unregistration and event publishing. The crash has only been observed on API 18 devices and results from a thread [safety bug in Android](https://issuetracker.google.com/issues/37002161). Similar crashes have been reported in the popular networking library OkHttp [#1520](https://github.com/square/okhttp/issues/1520) [#1338](https://github.com/square/okhttp/issues/1338). If this bug is impacting your applications, please open an issue on [our quickstart](https://github.com/twilio/voice-quickstart-android) and we will investigate potential fixes.