### PR TITLE
Use Voice Android SDK 3.0.0-beta5

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,7 +46,7 @@ android {
 dependencies {
     testImplementation 'junit:junit:4.12'
 
-    implementation 'com.twilio:voice-android:3.0.0-beta4'
+    implementation 'com.twilio:voice-android:3.0.0-beta5'
     implementation 'com.android.support:design:27.0.2'
     implementation 'com.android.support:appcompat-v7:27.0.2'
     implementation 'com.squareup.retrofit:retrofit:1.9.0'


### PR DESCRIPTION
https://www.twilio.com/docs/voice/voip-sdk/android/3x-changelog#300-beta5

### 3.0.0-beta5

March 4th, 2019

* Programmable Voice Android SDK 3.0.0-beta5 [[bintray]](https://bintray.com/twilio/releases/voice-android/3.0.0-beta5), [[docs]](https://media.twiliocdn.com/sdk/android/voice/releases/3.0.0-beta5/docs/)

#### Updates

- CLIENT-5534 Added `IceCandidateStats` and `IceCandidatePairStats` to `StatsReport`.

#### Improvements

- CLIENT-5516 Reduced connection time by removing a hostname lookup
- CLIENT-5688 Retry failed DNS resolution during reconnect

#### Bug Fixes

- CLIENT-5612 Fixed bug where Call may get disconnected when ipv6 WiFi network disappears when LTE connection is on
- CLIENT-5578 CLIENT-5688 Fixed bug where WiFi to WiFi network handover may disconnect the Call while LTE connection is on

#### Library Size Report

| ABI             | APK Size Impact |
| --------------- | --------------- |
| universal       | 15.4MB          |
| armeabi-v7a     | 3.4MB           |
| arm64-v8a       | 4MB             |
| x86             | 4.1MB           |
| x86_64          | 4.2MB           |

 
#### Known Issues

- CLIENT-5576 LTE to WiFI handover may cause one way audio. 
- CLIENT-5075 The SDK cannot be added alongside the Programmable Video SDK.
- CLIENT-4943 Restrictive networks may fail unless ICE servers are provided via `ConnectOptions.Builder.iceOptions(...)` or `AcceptOptions.Builder.iceOptions(...)`. ICE servers can be obtained from [Twilio Network Travarsal Service](https://www.twilio.com/stun-turn).
- CLIENT-4805 The SDK size is significantly larger than 2.x. A reduced size will be introduced during the beta period.
- CLIENT-5242 Occasional native crash in `AsyncTask` of registration/unregistration and event
publishing. The crash has only been observed on API 18 devices and results from a
thread [safety bug in Android](https://issuetracker.google.com/issues/37002161). Similar crashes
have been reported in the popular networking library OkHttp
[#1520](https://github.com/square/okhttp/issues/1520)
[#1338](https://github.com/square/okhttp/issues/1338). If this bug is impacting your applications,
please open an issue on [our quickstart](https://github.com/twilio/voice-quickstart-android) and
we will investigate potential fixes.