### PR TITLE
Use Voice Android SDK 3.0.0-beta8

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,7 +46,7 @@ android {
 dependencies {
     testImplementation 'junit:junit:4.12'
 
-    implementation 'com.twilio:voice-android:3.0.0-beta7'
+    implementation 'com.twilio:voice-android:3.0.0-beta8'
     implementation 'com.android.support:design:27.0.2'
     implementation 'com.android.support:appcompat-v7:27.0.2'
     implementation 'com.squareup.retrofit:retrofit:1.9.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,7 +46,7 @@ android {
 dependencies {
     testImplementation 'junit:junit:4.12'
 
-    implementation 'com.twilio:voice-android:3.0.0-beta5'
+    implementation 'com.twilio:voice-android:3.0.0-beta6'
     implementation 'com.android.support:design:27.0.2'
     implementation 'com.android.support:appcompat-v7:27.0.2'
     implementation 'com.squareup.retrofit:retrofit:1.9.0'


### PR DESCRIPTION
https://www.twilio.com/docs/voice/voip-sdk/android/3x-changelog#300-beta8

### 3.0.0-beta8

March 27th, 2019

* Programmable Voice Android SDK 3.0.0-beta8 [[bintray]](https://bintray.com/twilio/releases/voice-android/3.0.0-beta8), [[docs]](https://media.twiliocdn.com/sdk/android/voice/releases/3.0.0-beta8/docs/)

#### API Changes
- Attempts to connect a call via `Voice.connect(...)` or `CallInvite.accept(...)` that fail prior to reaching the connected state will always raise an `onConnectFailure(...)` with an error code. However, if `Call.disconnect()` is called while an attempt to connect or accept a call is made, the `onDisconnected(...)` will be raised with no error.

#### Updates 
- CLIENT-5808 CLIENT-5809 Updated the API documentation for `CallInvite.accept`.
- CLIENT-5811 Updated the API documentation for `Call`.

#### Bug Fixes
- CLIENT-5813 Network loss scenarios that resulted in a call failure now raise the `onConnectFailure(...)` callback. Previously these scenarios erroneously raised `onDisconnected(...)`.
- CLIENT-5754 A call that fails as a result of not establishing a media connection prior to being connected now raises the `onConnectFailure(...)` callback. Previously this scenario erroneously raised `onDisconnected(...)`.
- CLIENT-5821 The `packets_lost_fraction` value reported to Insights is correctly computed and within the expect range of 0 to 100.
- CLIENT-5835 Events were erroneously reported to Insights when the `ConnectOptions.enableInsights` property was set to false.

#### Known Issues

- CLIENT-5576 LTE to WiFI handover may cause one way audio. 
- CLIENT-5075 The SDK cannot be added alongside the Programmable Video SDK.
- CLIENT-4943 Restrictive networks may fail unless ICE servers are provided via `ConnectOptions.Builder.iceOptions(...)` or `AcceptOptions.Builder.iceOptions(...)`. ICE servers can be obtained from [Twilio Network Travarsal Service](https://www.twilio.com/stun-turn).
- CLIENT-5242 Occasional native crash in `AsyncTask` of registration/unregistration and event
publishing. The crash has only been observed on API 18 devices and results from a
thread [safety bug in Android](https://issuetracker.google.com/issues/37002161). Similar crashes
have been reported in the popular networking library OkHttp
[#1520](https://github.com/square/okhttp/issues/1520)
[#1338](https://github.com/square/okhttp/issues/1338). If this bug is impacting your applications,
please open an issue on [our quickstart](https://github.com/twilio/voice-quickstart-android) and
we will investigate potential fixes.

#### Library Size Report

| ABI             | App Size Increase |
| --------------- | ----------------- |
| universal       | 14.7MB          |
| armeabi-v7a     | 3.3MB           |
| arm64-v8a       | 3.8MB           |
| x86             | 3.9MB           |
| x86_64          | 4MB             |
