### PR TITLE
Use Voice Android SDK 3.0.0 GA version

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,7 +46,7 @@ android {
 dependencies {
     testImplementation 'junit:junit:4.12'
     
-    implementation 'com.twilio:voice-android:3.0.0-beta13'
+    implementation 'com.twilio:voice-android:3.0.0'
     implementation 'com.android.support:design:27.0.2'
     implementation 'com.android.support:appcompat-v7:27.0.2'
     implementation 'com.squareup.retrofit:retrofit:1.9.0'


### PR DESCRIPTION
https://www.twilio.com/docs/voice/voip-sdk/android/3x-changelog#300

### 3.0.0

April 25th, 2019

* Programmable Voice Android SDK 3.0.0 [[bintray]](https://bintray.com/twilio/releases/voice-android/3.0.0), [[docs]](https://media.twiliocdn.com/sdk/android/voice/releases/3.0.0/docs/)

#### Known Issues

- CLIENT-5075 The SDK cannot be added alongside the Programmable Video SDK.
- CLIENT-4943 Restrictive networks may fail unless ICE servers are provided via `ConnectOptions.Builder.iceOptions(...)` or `AcceptOptions.Builder.iceOptions(...)`. ICE servers can be obtained from [Twilio Network Travarsal Service](https://www.twilio.com/stun-turn).
- CLIENT-5242 Occasional native crash in `AsyncTask` of registration/unregistration and event
publishing. The crash has only been observed on API 18 devices and results from a
thread [safety bug in Android](https://issuetracker.google.com/issues/37002161). Similar crashes
have been reported in the popular networking library OkHttp
[#1520](https://github.com/square/okhttp/issues/1520)
[#1338](https://github.com/square/okhttp/issues/1338). If this bug is impacting your applications,
please open an issue on [our quickstart](https://github.com/twilio/voice-quickstart-android) and
we will investigate potential fixes.

#### Library Size Report

| ABI             | App Size Increase |
| --------------- | ----------------- |
| universal       | 14.7MB          |
| armeabi-v7a     | 3.3MB           |
| arm64-v8a       | 3.8MB           |
| x86             | 3.9MB           |
| x86_64          | 4MB             |

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
