### PR TITLE
Use Voice Android SDK 3.1.0 version

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,7 +46,7 @@ android {
 dependencies {
     testImplementation 'junit:junit:4.12'
     
-    implementation 'com.twilio:voice-android:3.0.0'
+    implementation 'com.twilio:voice-android:3.1.0'
     implementation 'com.android.support:design:27.0.2'
     implementation 'com.android.support:appcompat-v7:27.0.2'
     implementation 'com.squareup.retrofit:retrofit:1.9.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,7 +46,7 @@ android {
 dependencies {
     testImplementation 'junit:junit:4.12'
     
-    implementation 'com.twilio:voice-android:3.0.0-beta13'
+    implementation 'com.twilio:voice-android:3.0.0'
     implementation 'com.android.support:design:27.0.2'
     implementation 'com.android.support:appcompat-v7:27.0.2'
     implementation 'com.squareup.retrofit:retrofit:1.9.0'


### PR DESCRIPTION
https://www.twilio.com/docs/voice/voip-sdk/android/3x-changelog#310

### 3.1.0

May 16th, 2019

* Programmable Voice Android SDK 3.1.0 [[bintray]](https://bintray.com/twilio/releases/voice-android/3.1.0), [[docs]](https://media.twiliocdn.com/sdk/android/voice/releases/3.1.0/docs/)

#### Enhancements
##### Improved error codes

We now surface more details about errors encountered during [[TwilioVoice [Voice.register(...)](https://media.twiliocdn.com/sdk/android/voice/releases/3.1.0/docs/com/twilio/voice/Voice.html#register-java.lang.String-com.twilio.voice.Voice.RegistrationChannel-java.lang.String-com.twilio.voice.RegistrationListener-), [Voice.unregister(...)](https://media.twiliocdn.com/sdk/android/voice/releases/3.1.0/docs/com/twilio/voice/Voice.html#unregister-java.lang.String-com.twilio.voice.Voice.RegistrationChannel-java.lang.String-com.twilio.voice.UnregistrationListener-), [Voice.connect(...)](https://media.twiliocdn.com/sdk/android/voice/releases/3.1.0/docs/com/twilio/voice/Voice.html#connect-android.content.Context-com.twilio.voice.ConnectOptions-com.twilio.voice.Call.Listener-), and [CallInvite.accept(...)](https://media.twiliocdn.com/sdk/android/voice/releases/3.1.0/docs/com/twilio/voice/CallInvite.html#accept-android.content.Context-com.twilio.voice.AcceptOptions-com.twilio.voice.Call.Listener-). Previously, these functions reported these errors with the generic error [REGISTRATION_ERROR_CODE/31301](https://media.twiliocdn.com/sdk/android/voice/releases/3.1.0/docs/com/twilio/voice/RegistrationException.html#EXCEPTION_REGISTRATION_ERROR) or [EXCEPTION_CONNECTION_ERROR/31005](https://media.twiliocdn.com/sdk/android/voice/releases/3.1.0/docs/com/twilio/voice/CallException.html#EXCEPTION_CONNECTION_ERROR).

With the new error codes, you can make more informed decisions about how to remedy the problem. For example, error code `EXCEPTION_BAD_REQUEST` and `EXCEPTION_TOO_MANY_REQUEST` indicate potential programming issues, while `EXCEPTION_ACCESS_TOKEN_REJECTED` indicates an issue with your Access Token.

Please note, you may need to change your code if you have added special handling for [REGISTRATION_ERROR_CODE/31301](https://media.twiliocdn.com/sdk/android/voice/releases/3.1.0/docs/com/twilio/voice/RegistrationException.html#EXCEPTION_REGISTRATION_ERROR) or [EXCEPTION_CONNECTION_ERROR/31005](https://media.twiliocdn.com/sdk/android/voice/releases/3.1.0/docs/com/twilio/voice/CallException.html#EXCEPTION_CONNECTION_ERROR).

For more information see the [API docs](https://media.twiliocdn.com/sdk/android/voice/releases/3.1.0/docs/index.html)

The following is a summary of the new codes available for `Voice.register(...)` and `Voice.unregister(...)`:

| Error Code    | Error Message      |
| --------------| -------------------|
| 31400         | Bad Request        | 
| 31403         | Forbidden          | 
| 31404         | Not Found          | 
| 31408         | Request Timeout    | 
| 31409         | Conflict           | 
| 31426         | Upgrade Required. This is most likely related to a TLS version not accepted by Twilio's infrastructure   |
| 31429         | Too Many Requests  | 
| 31500         | Internal Server    | 
| 31502         | Bad Gateway        | 
| 31503         | Service Unavailable| 
| 31504         | Gateway Timeout    | 

The following is a summary of the new codes available for `Voice.connect(...)` and `CallInvite.accept(...)`:

| Error Code    | Error Message      |
| --------------| -------------------|
| 31009         | Transport error    |
| 31400         | Bad Request        | 
| 31403         | Forbidden          | 
| 31404         | Not Found          | 
| 31408         | Request Timeout    | 
| 31480         | Temporarily Unavailable| 
| 31481         | Call/Transaction Does Not Exist| 
| 31486         | Busy Here          | 
| 31487         | Request Terminated |
| 31500         | Internal Server    | 
| 31502         | Bad Gateway        | 
| 31503         | Service Unavailable| 
| 31504         | Gateway Timeout    | 
| 31530         | DNS Resolution Error |
| 31600         | Busy Everywhere    |
| 31603         | Decline            |
| 31604         | Does Not Exist Anywhere |

#### Bug Fixes

- CLIENT-6077 The SDK reports error events to Insights when exception occurs during registration/unregistration.

#### Known Issues

- CLIENT-5075 The SDK cannot be added alongside the Programmable Video SDK.
- CLIENT-4943 Restrictive networks may fail unless ICE servers are provided via `ConnectOptions.Builder.iceOptions(...)` or `AcceptOptions.Builder.iceOptions(...)`. ICE servers can be obtained from [Twilio Network Travarsal Service](https://www.twilio.com/stun-turn).
- CLIENT-5242 Occasional native crash in `AsyncTask` of registration/unregistration and event
publishing. The crash has only been observed on API 18 devices and results from a
thread [safety bug in Android](https://issuetracker.google.com/issues/37002161). Similar crashes
have been reported in the popular networking library OkHttp
[#1520](https://github.com/square/okhttp/issues/1520)
[#1338](https://github.com/square/okhttp/issues/1338). If this bug is impacting your applications,
please open an issue on [our quickstart](https://github.com/twilio/voice-quickstart-android) and
we will investigate potential fixes.

#### Library Size Report

| ABI             | App Size Increase |
| --------------- | ----------------- |
| universal       | 14.7MB          |
| armeabi-v7a     | 3.3MB           |
| arm64-v8a       | 3.8MB           |
| x86             | 3.9MB           |
| x86_64          | 4MB             |

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
