### PR TITLE
Use Voice Android SDK 3.1.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,7 +46,7 @@ android {
 dependencies {
     testImplementation 'junit:junit:4.12'
 
-    implementation 'com.twilio:voice-android:3.1.0'
+    implementation 'com.twilio:voice-android:3.1.1'
     implementation 'com.android.support:design:27.0.2'
     implementation 'com.android.support:appcompat-v7:27.0.2'
     implementation 'com.squareup.retrofit:retrofit:1.9.0'


### PR DESCRIPTION
### 3.1.1

June 12th, 2019

* Programmable Voice Android SDK 3.1.1 [[bintray]](https://bintray.com/twilio/releases/voice-android/3.1.1), [[docs]](https://twilio.github.io/twilio-voice-android/docs/3.1.1/)

#### Enhancements

- Switched CI provider for build, test, and release pipeline.
- The Twilio CDN will no longer host the Voice Android aar artifacts or Javadocs. All artifacts and javadocs previously hosted on the Twilio CDN will remain.

##### Accessing Artifacts

If you are downloading Voice Android SDK artifacts from the Twilio CDN then there are two
options available moving forward.

1. Follow our [Get Started with the Programmable Voice SDKs](https://www.twilio.com/docs/voice/voip-sdk#get-started-with-the-programmable-voice-sdks).
2. Download the artifacts [directly from Bintray](https://bintray.com/twilio/releases/voice-android#files/com/twilio/voice-android).

##### Viewing Javadocs
All Javadocs back to `3.0.0-preview1` are now hosted on [Github Pages](https://pages.github.com/)
with the following URL scheme. `https://twilio.github.io/twilio-voice-android/docs/{version}`

  - To view `3.1.1` Javadocs go to [https://twilio.github.io/twilio-voice-android/docs/3.1.1](https://twilio.github.io/twilio-voice-android/docs/3.1.1)

#### Known Issues

- CLIENT-5075 The SDK cannot be added alongside the Programmable Video SDK.
- CLIENT-4943 Restrictive networks may fail unless ICE servers are provided via `ConnectOptions.Builder.iceOptions(...)` or `AcceptOptions.Builder.iceOptions(...)`. ICE servers can be obtained from [Twilio Network Travarsal Service](https://www.twilio.com/stun-turn).
- CLIENT-5242 Occasional native crash in `AsyncTask` of registration/unregistration and event
publishing. The crash has only been observed on API 18 devices and results from a thread [safety bug in Android](https://issuetracker.google.com/issues/37002161). Similar crashes have been reported in the popular networking library OkHttp [#1520 (https://github.com/square/okhttp/issues/1520) [#1338](https://github.com/square/okhttp/issues/1338). If this bug is impacting your applications, please open an issue on [our quickstart](https://github.com/twilio/voice-quickstart-android) and we will investigate potential fixes.

#### Library Size Report

| ABI             | App Size Increase |
| --------------- | ----------------- |
| universal       | 14.7MB          |
| armeabi-v7a     | 3.3MB           |
| arm64-v8a       | 3.8MB           |
| x86             | 3.9MB           |
| x86_64          | 4MB             |




**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
