### PR TITLE
Consume Voice Android SDK 5.0.0 release

### DIFF
--- a/Docs/migration-guide-4.x-5.x.md
+++ b/Docs/migration-guide-4.x-5.x.md
@@ -1,0 +1,73 @@
+## 4.x to 5.x Migration Guide
+
+This document provides migration steps to 5.x release. `5.0.0` introduces an update to the Programmable Voice call model. Prior to `5.0.0`, when `Voice.register(...)` was invoked, the Voice SDK registered for two push notifications: a call and cancel push notification. The SDK now handles incoming call cancellations via a dedicated signaling mechanism. The `cancel` push notification is no longer required or supported by new releases of the SDK.
+
+If your application supports incoming calls, you MUST perform the following steps to comply with the new call model in 5.x:
+
+1. Upgrade Twilio Voice Android SDK to 5.0.0
+2. You must register via `Voice.register` when your App starts. This ensures that your App no longer receives “cancel” push notifications. A valid call push notification, when passed to `Voice.handleMessage(...)`, will still result in a `CallInvite` being raise to the provided `MessageListener`. A `CancelledCallInvite` will be raised to the provided `MessageListener` if any of the following events occur:
+    - The call is prematurely disconnected by the caller.
+    - The callee does not accept or reject the call within 30 seconds.
+    - The Voice SDK is unable to establish a connection to Twilio.
+
+
+    A `CancelledCallInvite` will not be raised if a `CallInvite` is accepted or rejected.
+
+
+    To register with the new SDK when the app is launched:
+    private RegistrationListener registrationListener() {
+        return new RegistrationListener() {
+            @Override
+            public void onRegistered(String accessToken, String fcmToken) {
+                Log.d(TAG, "Successfully registered FCM " + fcmToken);
+            }
+    
+            @Override
+            public void onError(RegistrationException error, String accessToken, String fcmToken) {
+                String message = String.format("Registration Error: %d, %s", error.getErrorCode(), error.getMessage());
+                Log.e(TAG, message);
+            }
+        };
+    }
+    
+    private void registerForCallInvites() {
+        final String fcmToken = FirebaseInstanceId.getInstance().getToken();
+        if (fcmToken != null) {
+            Log.i(TAG, "Registering with FCM");
+            Voice.register(accessToken, Voice.RegistrationChannel.FCM, fcmToken, registrationListener);
+        }
+    }
+
+
+    Please note that if the app is updated to use 5.0.0 release but never launched to perform the registration, the mobile client will still receive "cancel" notifications. If “cancel” notification is passed to `Voice.handleMessage(…)`, it will return `false`. 
+3. Both `Voice.handleMessage(...)` methods require an Android `Context` as the first argument. You must update the method call to match the new method signature.
+4. `MessageListener.onCancelledCallInvite` has been updated to include `@Nullable` `CallException callException` as the second argument. A `CallException` will be provided if a network or server error resulted in the cancellation. You need to update `MessageListener` implementation in your code to the following:
+
+
+    boolean valid = Voice.handleMessage(context, remoteMessage.getData(), new MessageListener() {
+        @Override
+        public void onCallInvite(@NonNull CallInvite callInvite) {
+            // Handle CallInvite
+        }
+    
+        @Override
+       public void onCancelledCallInvite(@NonNull CancelledCallInvite cancelledCallInvite, @Nullable CallException callException) {
+            // Handle CancelledCallInvite
+        }
+    });
+
+
+5. If you were previously toggling `enableInsights` or specifying a `region` via `ConnectOptions`, you must now set the `insights` and `region` property via `Voice.enableInsights(…)` and `Voice.setRegion(…)` respectively. You must do so before calling `Voice.connect(…)` or `Voice.handleMessage(…)`. 
+    Please note : 
+    - Sending stats data to Insights is enabled by default
+    - The default region uses Global Low Latency routing, which establishes a connection with the closest region to the user
+
+
+    Voice.enableInsights(true);
+    Voice.setRegion(region);
+    ConnectOptions connectOptions = new ConnectOptions.Builder(accessToken)
+            .build();
+    call = Voice.connect(getApplicationContext(), connectOptions, outgoingCallListener());
+
+You can reference the 5.0.0 quickstart when migrating your application.
+A summary of the API changes and new Insights events can be found in the 5.0.0 changelog.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ branch. If you are using SDK 2.x, we highly recommend planning your migration to
 Get started with Voice on Android:
 
 - [Quickstart](#quickstart) - Run the quickstart app
+- [Migration Guide 4.x to 5.x](https://github.com/twilio/voice-quickstart-android/blob/master/Docs/migration-guide-4.x-5.x.md) - Migrating from 4.x to 5.x
 - [New Features 4.0](https://github.com/twilio/voice-quickstart-android/blob/master/Docs/new-features-4.0.md) - New features in 4.0
 - [Migration Guide 3.x to 4.x](https://github.com/twilio/voice-quickstart-android/blob/master/Docs/migration-guide-3.x-4.x.md) - Migrating from 3.x to 4.x
 - [New Features 3.0](https://github.com/twilio/voice-quickstart-android/blob/master/Docs/new-features-3.0.md) - New features in 3.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-> NOTE: This sample application uses the Programmable Voice Android 4.x APIs. For an example using 
-our 2.x APIs, please see the [2.x](https://github.com/twilio/voice-quickstart-android/tree/2.x) 
-branch. If you are using SDK 2.x, we highly recommend planning your migration to 4.0 as soon as possible. Support for 2.x will cease 1/1/2020. Until then, SDK 2.x will only receive fixes for critical or security related issues.
+> NOTE: This sample application uses the Programmable Voice Android 5.x APIs. If you are using prior versions of the SDK, we highly recommend planning your migration to 5.0 as soon as possible.
 
 # Twilio Voice Quickstart for Android
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,7 +45,7 @@ android {
 dependencies {
     testImplementation 'junit:junit:4.12'
 
-    implementation 'com.twilio:voice-android:4.5.0'
+    implementation 'com.twilio:voice-android:5.0.0'
     implementation 'com.android.support:design:28.0.0'
     implementation 'com.android.support:support-media-compat:28.0.0'
     implementation 'com.android.support:animated-vector-drawable:28.0.0'

--- a/app/src/main/java/com/twilio/voice/quickstart/fcm/VoiceFirebaseMessagingService.java
+++ b/app/src/main/java/com/twilio/voice/quickstart/fcm/VoiceFirebaseMessagingService.java
@@ -12,12 +12,14 @@ import android.os.Build;
 import android.os.Bundle;
 import android.service.notification.StatusBarNotification;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.v4.app.NotificationCompat;
 import android.support.v4.content.LocalBroadcastManager;
 import android.util.Log;
 
 import com.google.firebase.messaging.FirebaseMessagingService;
 import com.google.firebase.messaging.RemoteMessage;
+import com.twilio.voice.CallException;
 import com.twilio.voice.CallInvite;
 import com.twilio.voice.CancelledCallInvite;
 import com.twilio.voice.MessageListener;
@@ -57,9 +59,8 @@ public class VoiceFirebaseMessagingService extends FirebaseMessagingService {
         // Check if message contains a data payload.
         if (remoteMessage.getData().size() > 0) {
             Map<String, String> data = remoteMessage.getData();
-            final int notificationId = (int) System.currentTimeMillis();
 
-            boolean valid = Voice.handleMessage(remoteMessage.getData(), new MessageListener() {
+            boolean valid = Voice.handleMessage(this, remoteMessage.getData(), new MessageListener() {
                 @Override
                 public void onCallInvite(@NonNull CallInvite callInvite) {
                     final int notificationId = (int) System.currentTimeMillis();
@@ -68,7 +69,7 @@ public class VoiceFirebaseMessagingService extends FirebaseMessagingService {
                 }
 
                 @Override
-                public void onCancelledCallInvite(@NonNull CancelledCallInvite cancelledCallInvite) {
+                public void onCancelledCallInvite(@NonNull CancelledCallInvite cancelledCallInvite, @Nullable CallException callException) {
                     VoiceFirebaseMessagingService.this.cancelNotification(cancelledCallInvite);
                     VoiceFirebaseMessagingService.this.sendCancelledCallInviteToActivity(
                             cancelledCallInvite);


### PR DESCRIPTION
### 5.0.0

October 28th, 2019

* Programmable Voice Android SDK 5.0.0 [[bintray]](https://bintray.com/twilio/releases/voice-android/5.0.0), [[docs]](https://twilio.github.io/twilio-voice-android/docs/5.0.0/)

This release introduces an update to the Programmable Voice call model. Prior to `5.0.0`, when 
`Voice.register(...)` is invoked, the Voice SDK registers for two push
notifications: a call and cancel push notification. The call and cancel push notification payloads 
could then be passed as arguments to `Voice.handleMessage(...)` and your application would be
provided with a callback via `MessageListener` indicating if the message was a `CallInvite` 
or `CancelledCallInvite`.

Starting with 5.0.0, when `Voice.register(...)` is invoked, the Voice SDK will register
for call push notifications and cancelled call invites will be determined via a signaling connection. 
`Voice.handleMessage(...)` no longer processes cancel push notification payloads and will return
`false` if provided with a cancel message. As a result, developers must re-register via
`Voice.register(...)` after upgrading their application to `5.0.0` to stop receiving cancel push
notifications.

#### CallInvite and CancelledCallInvite Updates

A valid call push notification, when passed to `Voice.handleMessage(...)`, will still result in a `CallInvite`
being raise to the provided `MessageListener`. A `CancelledCallInvite` will be raised to
the provided `MessageListener` if any of the following events occur:

- The call is prematurely disconnected by the caller.
- The callee does not accept or reject the call within 30 seconds.
- The Voice SDK is unable to establish a connection to Twilio.

A `CancelledCallInvite` will not be raised if a `CallInvite` is accepted or rejected.


#### Insights 

To provide observability for incoming call cancellations the following Insights events have been added:

| Event Group | Level | Event Name | Description |
|-------------|-------|------------|-------------|
| connection| INFO | listen | Raised when an attempt to listen for cancellations is made |
| connection| INFO | listening | Raised when an attempt to listen for cancellations has succeeded |
| connection| INFO | cancel | Raised when a cancellation has been reported |
| connection| ERROR | listening-error | Raised when an attempt to listen for cancellation has failed |
| registration | ERROR | unsupported-cancel-message-error | Raised when a "cancel" push notification is processed by the SDK. This version of the SDK does not support "cancel" push notifications |

#### API Updates

- `MessageListener.onCancelledCallInvite` has been updated to the following signature.

    ```
    void onCancelledCallInvite(@NonNull CancelledCallInvite cancelledCallInvite, @Nullable CallException callException)
    ```

    The provided `CallException` will indicate if a call was cancelled as the result of an error. If
    no error occurred, then the `CallException` is `null`.

- Both `Voice.handleMessage(...)` methods require an Android `Context` as the first argument.

- `CallInvite` class includes `isValid(...)` utility method to validate whether the payload is a valid notification sent by Twilio. A valid notification payload will result in a `CallInvite` being raised via `MessageListener.onCallInvite(...)` callback when passed to `Voice.handleMessage(...)`. 

- Enabling insights and setting the region are now specified on the `Voice` class. These options were previously accessible on `ConnectOptions` and `AcceptOptions`. 
	* Sending stats data to Insights is enabled by default. 
	* The default region uses Global Low Latency routing, which establishes a connection with the closest region to the user.

	Below are the new methods signatures introduced in `Voice` class.
	
	```
	public static boolean isInsightsEnabled();
	public static void enableInsights(boolean enable);
	@NonNull public static String getRegion();
	public static void setRegion(@NonNull String region)
	```

- Introduced a new error code that gets surfaced when `handleMessage(..)` API is called with push notification bundle with `twilio.voice.cancel` as the `twi_message_type`.

| Error Code | Level | Error Message | Description |
| ---------- |-------|-------------------|-------------|
| 31302 | Error | Unsupported Cancel Message Error |This version of the SDK no longer supports processing cancel push notification messages. You must register via Voice.register(...) with this version of the SDK to stop receiving cancel push notification messages. Cancellations are now handled internally and reported to you on behalf of the SDK. |

#### Enhancements

- CLIENT-6757 Updated the Android Gradle Plugin to 3.5.0 and Gradle to 5.4.1.

#### Known Issues

- CLIENT-4943 Restrictive networks may fail unless ICE servers are provided via `ConnectOptions.Builder.iceOptions(...)` or `AcceptOptions.Builder.iceOptions(...)`. ICE servers can be obtained from [Twilio Network Travarsal Service](https://www.twilio.com/stun-turn).
- CLIENT-5242 Occasional native crash in `AsyncTask` of registration/unregistration and event
publishing. The crash has only been observed on API 18 devices and results from a
thread [safety bug in Android](https://issuetracker.google.com/issues/37002161). Similar crashes
have been reported in the popular networking library OkHttp
[#1520](https://github.com/square/okhttp/issues/1520)
[#1338](https://github.com/square/okhttp/issues/1338). If this bug is impacting your applications,
please open an issue on [our quickstart](https://github.com/twilio/voice-quickstart-android) and
we will investigate potential fixes.

#### Library Size Report

| ABI             | App Size Increase |
| --------------- | ----------------- |
| universal       | 14.7MB          |
| armeabi-v7a     | 3.3MB           |
| arm64-v8a       | 3.8MB           |
| x86             | 3.9MB           |
| x86_64          | 4MB             |


**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
