### PR TITLE
Use Voice Android SDK 5.0.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,7 +45,7 @@ android {
 dependencies {
     testImplementation 'junit:junit:4.12'
 
-    implementation 'com.twilio:voice-android:5.0.0'
+    implementation 'com.twilio:voice-android:5.0.1'
     implementation 'com.android.support:design:28.0.0'
     implementation 'com.android.support:support-media-compat:28.0.0'
     implementation 'com.android.support:animated-vector-drawable:28.0.0'


### PR DESCRIPTION
### 5.0.1

November 19th, 2019

#### Enhancements

- Incoming call handling improvements. Previously, if we encountered network issues before an incoming call was answered or rejected, we disconnected the call. With this release, we will continue to try and establish a connection to Twilio for a maximum of 40 seconds before we disconnect the call.

- We now publish the negotiated codec and its associated parameters to Insights.

| Event Group | Level | Event Name | Description |
|-------------|-------|------------|-------------|
| settings    | INFO  | codec | Raised when the codec has been selected |

#### Other Improvements

- Improved the way we perform DNS resolution. Previously, some DNS requests could indirectly block the main thread. This is no longer the case.

#### Things to Note

- Restrictive networks may fail unless ICE servers are provided via `ConnectOptions.Builder.iceOptions(...)` or `AcceptOptions.Builder.iceOptions(...)`. ICE servers can be obtained from [Twilio Network Travarsal Service](https://www.twilio.com/stun-turn).
- Occasional native crash in `AsyncTask` of registration/unregistration and event
publishing. The crash has only been observed on API 18 devices and results from a
thread [safety bug in Android](https://issuetracker.google.com/issues/37002161). Similar crashes
have been reported in the popular networking library OkHttp
[#1520](https://github.com/square/okhttp/issues/1520)
[#1338](https://github.com/square/okhttp/issues/1338). If this bug is impacting your applications,
please open an issue on [our quickstart](https://github.com/twilio/voice-quickstart-android) and
we will investigate potential fixes.

#### Library Size Report

| ABI             | App Size Increase |
| --------------- | ----------------- |
| universal       | 14.9MB          |
| armeabi-v7a     | 3.3MB           |
| arm64-v8a       | 3.8MB           |
| x86             | 4MB             |
| x86_64          | 4.1MB           |

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
