### PR TITLE
CLIENT-7108: Play custom ringtone on caller side

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ There are number of techniques you can use to ensure that access token expiry is
 
 ## Playing Custom Ringtone 
 
-When [answerOnBridge](https://www.twilio.com/docs/voice/twiml/dial#answeronbridge) is enabled in the `<Dial>` TwiML verb, the caller will not hear the ringback while the call is ringing and awaiting to be accepted on the callee's side. The application can use the `SoundPoolManager` to play custom audio files between the `Call.Listener.onRinging()` and the `Call.Listener.onConnected()` callbacks. To enabale this behavior, add `playCustomRingback` as an environment variable or a property in `local.properties` file and set it to `true`.
+When [answerOnBridge](https://www.twilio.com/docs/voice/twiml/dial#answeronbridge) is enabled in the `<Dial>` TwiML verb, the caller will not hear the ringback while the call is ringing and awaiting to be accepted on the callee's side. The application can use the `SoundPoolManager` to play custom audio files between the `Call.Listener.onRinging()` and the `Call.Listener.onConnected()` callbacks. To enable this behavior, add `playCustomRingback` as an environment variable or a property in `local.properties` file and set it to `true`.
 
 ```
 playCustomRingback=true

--- a/README.md
+++ b/README.md
@@ -245,10 +245,10 @@ There are number of techniques you can use to ensure that access token expiry is
 
 ## Playing Custom Ringtone 
 
-When [answerOnBridge](https://www.twilio.com/docs/voice/twiml/dial#answeronbridge) is enabled in the `<Dial>` TwiML verb, the caller will not hear the ringback while the call is ringing and awaiting to be accepted on the callee's side. The application can use the `SoundPoolManager` to play custom audio files between the `Call.Listener.onRinging()` and the `Call.Listener.onConnected()` callbacks. To enabale this behavior, set the `playCustomRingback``buildConfigField` to `true` in [build.gradle](https://github.com/twilio/voice-quickstart-android/blob/master/app/build.gradle#L24-L28).
+When [answerOnBridge](https://www.twilio.com/docs/voice/twiml/dial#answeronbridge) is enabled in the `<Dial>` TwiML verb, the caller will not hear the ringback while the call is ringing and awaiting to be accepted on the callee's side. The application can use the `SoundPoolManager` to play custom audio files between the `Call.Listener.onRinging()` and the `Call.Listener.onConnected()` callbacks. To enabale this behavior, add `playCustomRingback` as an environment variable or a property in `local.properties` file and set it to `true`.
 
 ```
-buildConfigField("boolean", "playCustomRingback", "true")
+playCustomRingback=true
 ```
 
 ## Managing Push Credentials

--- a/README.md
+++ b/README.md
@@ -243,6 +243,14 @@ There are number of techniques you can use to ensure that access token expiry is
 - Retain the access token along with the timestamp of when it was requested so you can verify ahead of time whether the token has already expired based on the `time-to-live` being used by your server.
 - Prefetch the access token whenever the `Application`, `Service`, `Activity`, or `Fragment` associated with an outgoing call is created.
 
+## Playing Custom Ringtone 
+
+When [answerOnBridge](https://www.twilio.com/docs/voice/twiml/dial#answeronbridge) is enabled in the `<Dial>` TwiML verb, the caller will not hear the ringback while the call is ringing and awaiting to be accepted on the callee's side. The application can use the `SoundPoolManager` to play custom audio files between the `Call.Listener.onRinging()` and the `Call.Listener.onConnected()` callbacks. To enabale this behavior, set the `playCustomRingback``buildConfigField` to `true` in [build.gradle](https://github.com/twilio/voice-quickstart-android/blob/master/app/build.gradle#L24-L28).
+
+```
+buildConfigField("boolean", "playCustomRingback", "true")
+```
+
 ## Managing Push Credentials
 
 A Push Credential is a record for a push notification channel, for Android this Push Credential is a push notification channel record for FCM or GCM. Push Credentials are managed in the console under [Mobile Push Credentials](https://www.twilio.com/console/voice/sdks/credentials).

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,6 +21,10 @@ android {
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             signingConfig signingConfigs.debug
+            buildConfigField("boolean", "playCustomRingback", "false")
+        }
+        debug {
+            buildConfigField("boolean", "playCustomRingback", "false")
         }
     }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,25 @@
 apply plugin: 'com.android.application'
 
+ext.playCustomRingback = {
+    def playCustomRingback  = System.getenv("playCustomRingback");
+
+    if (playCustomRingback == null) {
+        logger.log(LogLevel.INFO, "Could not locate playCustomRingback environment variable. " +
+                "Trying local.properties")
+        Properties properties = new Properties()
+        if (project.rootProject.file('local.properties').exists()) {
+            properties.load(project.rootProject.file('local.properties').newDataInputStream())
+            playCustomRingback = properties.getProperty('playCustomRingback')
+        }
+    }
+
+    if (playCustomRingback == null) {
+        playCustomRingback = false
+    }
+
+    return playCustomRingback;
+}
+
 android {
     compileSdkVersion 28
 
@@ -21,10 +41,10 @@ android {
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             signingConfig signingConfigs.debug
-            buildConfigField("boolean", "playCustomRingback", "false")
+            buildConfigField("boolean", "playCustomRingback", "${playCustomRingback()}")
         }
         debug {
-            buildConfigField("boolean", "playCustomRingback", "false")
+            buildConfigField("boolean", "playCustomRingback", "${playCustomRingback()}")
         }
     }
 

--- a/app/src/main/java/com/twilio/voice/quickstart/VoiceActivity.java
+++ b/app/src/main/java/com/twilio/voice/quickstart/VoiceActivity.java
@@ -201,13 +201,24 @@ public class VoiceActivity extends AppCompatActivity {
             @Override
             public void onRinging(Call call) {
                 Log.d(TAG, "Ringing");
-                soundPoolManager.getInstance(VoiceActivity.this).playRinging();
+                /*
+                 * When [answerOnBridge](https://www.twilio.com/docs/voice/twiml/dial#answeronbridge)
+                 * is enabled in the <Dial> TwiML verb, the caller will not hear the ringback while
+                 * the call is ringing and awaiting to be accepted on the callee's side. The application
+                 * can use the `SoundPoolManager` to play custom audio files between the
+                 * `Call.Listener.onRinging()` and the `Call.Listener.onConnected()` callbacks.
+                 */
+                if (BuildConfig.playCustomRingback) {
+                    soundPoolManager.getInstance(VoiceActivity.this).playRinging();
+                }
             }
 
             @Override
             public void onConnectFailure(Call call, CallException error) {
                 setAudioFocus(false);
-                soundPoolManager.getInstance(VoiceActivity.this).stopRinging();
+                if (BuildConfig.playCustomRingback) {
+                    soundPoolManager.getInstance(VoiceActivity.this).stopRinging();
+                }
                 Log.d(TAG, "Connect failure");
                 String message = String.format("Call Error: %d, %s", error.getErrorCode(), error.getMessage());
                 Log.e(TAG, message);
@@ -218,7 +229,9 @@ public class VoiceActivity extends AppCompatActivity {
             @Override
             public void onConnected(Call call) {
                 setAudioFocus(true);
-                soundPoolManager.getInstance(VoiceActivity.this).stopRinging();
+                if (BuildConfig.playCustomRingback) {
+                    soundPoolManager.getInstance(VoiceActivity.this).stopRinging();
+                }
                 Log.d(TAG, "Connected");
                 activeCall = call;
             }
@@ -236,7 +249,9 @@ public class VoiceActivity extends AppCompatActivity {
             @Override
             public void onDisconnected(Call call, CallException error) {
                 setAudioFocus(false);
-                soundPoolManager.getInstance(VoiceActivity.this).stopRinging();
+                if (BuildConfig.playCustomRingback) {
+                    soundPoolManager.getInstance(VoiceActivity.this).stopRinging();
+                }
                 Log.d(TAG, "Disconnected");
                 if (error != null) {
                     String message = String.format("Call Error: %d, %s", error.getErrorCode(), error.getMessage());

--- a/app/src/main/java/com/twilio/voice/quickstart/VoiceActivity.java
+++ b/app/src/main/java/com/twilio/voice/quickstart/VoiceActivity.java
@@ -50,7 +50,6 @@ import com.twilio.voice.RegistrationListener;
 import com.twilio.voice.Voice;
 
 import java.util.HashMap;
-import java.util.Map;
 
 public class VoiceActivity extends AppCompatActivity {
 

--- a/app/src/main/java/com/twilio/voice/quickstart/VoiceActivity.java
+++ b/app/src/main/java/com/twilio/voice/quickstart/VoiceActivity.java
@@ -50,6 +50,7 @@ import com.twilio.voice.RegistrationListener;
 import com.twilio.voice.Voice;
 
 import java.util.HashMap;
+import java.util.Map;
 
 public class VoiceActivity extends AppCompatActivity {
 
@@ -201,11 +202,13 @@ public class VoiceActivity extends AppCompatActivity {
             @Override
             public void onRinging(Call call) {
                 Log.d(TAG, "Ringing");
+                soundPoolManager.getInstance(VoiceActivity.this).playRinging();
             }
 
             @Override
             public void onConnectFailure(Call call, CallException error) {
                 setAudioFocus(false);
+                soundPoolManager.getInstance(VoiceActivity.this).stopRinging();
                 Log.d(TAG, "Connect failure");
                 String message = String.format("Call Error: %d, %s", error.getErrorCode(), error.getMessage());
                 Log.e(TAG, message);
@@ -216,6 +219,7 @@ public class VoiceActivity extends AppCompatActivity {
             @Override
             public void onConnected(Call call) {
                 setAudioFocus(true);
+                soundPoolManager.getInstance(VoiceActivity.this).stopRinging();
                 Log.d(TAG, "Connected");
                 activeCall = call;
             }

--- a/app/src/main/java/com/twilio/voice/quickstart/VoiceActivity.java
+++ b/app/src/main/java/com/twilio/voice/quickstart/VoiceActivity.java
@@ -236,6 +236,7 @@ public class VoiceActivity extends AppCompatActivity {
             @Override
             public void onDisconnected(Call call, CallException error) {
                 setAudioFocus(false);
+                soundPoolManager.getInstance(VoiceActivity.this).stopRinging();
                 Log.d(TAG, "Disconnected");
                 if (error != null) {
                     String message = String.format("Call Error: %d, %s", error.getErrorCode(), error.getMessage());


### PR DESCRIPTION
#### Description
Implemented playing custom ringtone on the caller side. 

#### Validation
Validated the changes by toggling the `answerOnBridge` flag.

* When `answerOnBridge` is `true`, the custom ringtone starts playing when `onRigning()` callback is received and continues to play until the call is connected or disconnected.
* When `answerOnBridge` is `false`, the custom ringtone starts playing when `onRigning()` callback is received and continues to play until the call is connected to Twilio infrastructure. Once the call is connected to Twilio infrastructure `hurl` plays a ringtone until the call is connected to callee or call is disconnected.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
