### PR TITLE
Use AudioSwitch with Quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,54 +281,8 @@ Please ensure that after deleting the Push Credential you remove or replace the 
 ## Troubleshooting Audio
 The following sections provide guidance on how to ensure optimal audio quality in your applications.
 
-### Configuring AudioManager
-
-The `AudioManager` configuration guidance below is meant to provide optimal audio experience when in a `Call`. This configuration is inspired by the [WebRTC Android example](https://chromium.googlesource.com/external/webrtc/+/refs/heads/master/examples/androidapp/src/org/appspot/apprtc/AppRTCAudioManager.java) and the [Android documentation](https://developer.android.com/reference/android/media/AudioFocusRequest).
-
-```
- private void setAudioFocus(boolean setFocus) {
-    if (audioManager != null) {
-        if (setFocus) {
-            savedAudioMode = audioManager.getMode();
-            // Request audio focus before making any device switch.
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                AudioAttributes playbackAttributes = new AudioAttributes.Builder()
-                        .setUsage(AudioAttributes.USAGE_VOICE_COMMUNICATION)
-                        .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
-                        .build();
-                AudioFocusRequest focusRequest = new AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT)
-                        .setAudioAttributes(playbackAttributes)
-                        .setAcceptsDelayedFocusGain(true)
-                        .setOnAudioFocusChangeListener(new AudioManager.OnAudioFocusChangeListener() {
-                            @Override
-                            public void onAudioFocusChange(int i) {
-                            }
-                        })
-                        .build();
-                audioManager.requestAudioFocus(focusRequest);
-            } else {
-                int focusRequestResult = audioManager.requestAudioFocus(new AudioManager.OnAudioFocusChangeListener() {
-
-		                                       @Override
-		                                       public void onAudioFocusChange(int focusChange) {
-		                                       }
-		                                   }, AudioManager.STREAM_VOICE_CALL,
-                        AudioManager.AUDIOFOCUS_GAIN_TRANSIENT);
-            }
-            /*
-             * Start by setting MODE_IN_COMMUNICATION as default audio mode. It is
-             * required to be in this mode when playout and/or recording starts for
-             * best possible VoIP performance. Some devices have difficulties with speaker mode
-             * if this is not set.
-             */
-            audioManager.setMode(AudioManager.MODE_IN_COMMUNICATION);
-        } else {
-            audioManager.setMode(savedAudioMode);
-            audioManager.abandonAudioFocus(null);
-        }
-    }
-}
-```
+### Managing Audio Devices with AudioSwitch
+The quickstart uses [AudioSwitch](https://github.com/twilio/audioswitch) to control [audio focus](https://developer.android.com/guide/topics/media-apps/audio-focus) and manage audio devices within the application. If you have an issue or question related to audio management, please open an issue in the [AudioSwitch](https://github.com/twilio/audioswitch) project.
 
 ### Configuring Hardware Audio Effects
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -69,6 +69,7 @@ android {
 dependencies {
     testImplementation 'junit:junit:4.12'
 
+    implementation 'com.twilio:audioswitch:0.1.0'
     implementation 'com.twilio:voice-android:5.2.0'
     implementation 'com.android.support:design:28.0.0'
     implementation 'com.android.support:support-media-compat:28.0.0'

--- a/app/src/main/res/drawable/ic_bluetooth_white_24dp.xml
+++ b/app/src/main/res/drawable/ic_bluetooth_white_24dp.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M17.71,7.71L12,2h-1v7.59L6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 11,14.41L11,22h1l5.71,-5.71 -4.3,-4.29 4.3,-4.29zM13,5.83l1.88,1.88L13,9.59L13,5.83zM14.88,16.29L13,18.17v-3.76l1.88,1.88z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_headset_mic_white_24dp.xml
+++ b/app/src/main/res/drawable/ic_headset_mic_white_24dp.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M12,1c-4.97,0 -9,4.03 -9,9v7c0,1.66 1.34,3 3,3h3v-8H5v-2c0,-3.87 3.13,-7 7,-7s7,3.13 7,7v2h-4v8h4v1h-7v2h6c1.66,0 3,-1.34 3,-3V10c0,-4.97 -4.03,-9 -9,-9z"/>
+</vector>

--- a/app/src/main/res/menu/menu.xml
+++ b/app/src/main/res/menu/menu.xml
@@ -3,9 +3,10 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <item android:id="@+id/speaker_menu_item"
-        android:title="@string/turn_speaker_on"
-        android:icon="@drawable/ic_volume_up_white_24dp"
-        app:showAsAction="ifRoom"/>
+    <item
+        android:id="@+id/menu_audio_device"
+        android:icon="@drawable/ic_phonelink_ring_white_24dp"
+        android:title="@string/audio_device"
+        app:showAsAction="ifRoom" />
 
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,8 +1,9 @@
 <resources>
     <string name="app_name">Voice Quickstart</string>
-    <string name="turn_speaker_on">Speaker ON</string>
+    <string name="audio_device">Audio Device</string>
     <string name="callee">client identity or phone number</string>
     <string name="answer">Answer</string>
     <string name="decline">Decline</string>
     <string name="callHint">Dial a client name or phone number. Leaving the field empty results in an automated response.</string>
+    <string name="select_device">Select Audio Device</string>
 </resources>


### PR DESCRIPTION
## Description

This PR uses [AudioSwitch](https://github.com/twilio/audioswitch), a new Android library for managing audio routing in real-time communication apps. Initial inspiration from the [Video Android Collaboration App PR](https://github.com/twilio/twilio-video-app-android/pull/80) and the [Video Android Quickstart](https://github.com/twilio/video-quickstart-android/pull/504). See the screenshots below as a visualization, but library enables:

* Managing the audio focus when connecting and disconnecting from a room
* Enables users to select an audio device
* Monitors changes in audio devices and updates the UI accordingly.

![device-2020-05-08-124201](https://user-images.githubusercontent.com/1734140/81433098-a7048780-9129-11ea-94c9-e907fcf73374.png)
![device-2020-05-08-124242](https://user-images.githubusercontent.com/1734140/81433103-a79d1e00-9129-11ea-9941-546b6a376e01.png)
