### PR TITLE
Upgrade audioswitch to 0.1.3

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -69,7 +69,7 @@ android {
 dependencies {
     testImplementation 'junit:junit:4.12'
 
-    implementation 'com.twilio:audioswitch:0.1.2'
+    implementation 'com.twilio:audioswitch:0.1.3'
     implementation 'com.twilio:voice-android:5.2.0'
     implementation 'com.android.support:design:28.0.0'
     implementation 'com.android.support:support-media-compat:28.0.0'


### PR DESCRIPTION
Upgraded audioswitch to 0.1.3

**Chagelog**

### 0.1.3

Bug Fixes

- Fixed crash by adding a default bluetooth device name.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
