### PR TITLE
Use Voice Android SDK 5.3.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -70,7 +70,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 
     implementation 'com.twilio:audioswitch:0.1.3'
-    implementation 'com.twilio:voice-android:5.2.0'
+    implementation 'com.twilio:voice-android:5.3.0'
     implementation 'com.android.support:design:28.0.0'
     implementation 'com.android.support:support-media-compat:28.0.0'
     implementation 'com.android.support:animated-vector-drawable:28.0.0'

--- a/app/src/main/java/com/twilio/voice/quickstart/VoiceActivity.java
+++ b/app/src/main/java/com/twilio/voice/quickstart/VoiceActivity.java
@@ -51,6 +51,7 @@ import com.twilio.voice.Voice;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Set;
 import java.util.List;
 import java.util.Locale;
 
@@ -276,6 +277,28 @@ public class VoiceActivity extends AppCompatActivity {
                     Snackbar.make(coordinatorLayout, message, Snackbar.LENGTH_LONG).show();
                 }
                 resetUI();
+            }
+            /*
+             * currentWarnings: existing quality warnings that have not been cleared yet
+             * previousWarnings: last set of warnings prior to receiving this callback
+             *
+             * Example:
+             *   - currentWarnings: { A, B }
+             *   - previousWarnings: { B, C }
+             *
+             * Newly raised warnings = currentWarnings - intersection = { A }
+             * Newly cleared warnings = previousWarnings - intersection = { C }
+             */
+            public void onCallQualityWarningsChanged(@NonNull Call call,
+                                              @NonNull Set<Call.CallQualityWarning> currentWarnings,
+                                              @NonNull Set<Call.CallQualityWarning> previousWarnings) {
+                currentWarnings.retainAll(previousWarnings);
+                previousWarnings.removeAll(currentWarnings);
+                String message = String.format(
+                        Locale.US,
+                        "Newly raised warnings: " + currentWarnings + " Clear warnings " + previousWarnings);
+                Log.e(TAG, message);
+                Snackbar.make(coordinatorLayout, message, Snackbar.LENGTH_LONG).show();
             }
         };
     }

--- a/exampleCustomAudioDevice/build.gradle
+++ b/exampleCustomAudioDevice/build.gradle
@@ -45,7 +45,7 @@ android {
 dependencies {
     testImplementation 'junit:junit:4.12'
 
-    implementation 'com.twilio:voice-android:5.2.0'
+    implementation 'com.twilio:voice-android:5.3.0'
     implementation 'com.android.support:design:28.0.0'
     implementation 'com.android.support:support-media-compat:28.0.0'
     implementation 'com.android.support:animated-vector-drawable:28.0.0'


### PR DESCRIPTION
### [5.3.0](https://www.twilio.com/docs/voice/voip-sdk/android/3x-changelog#530)

June 3rd, 2020

* Programmable Voice Android SDK 5.3.0 [[bintray]](https://bintray.com/twilio/releases/voice-android/5.3.0), [[docs]](https://twilio.github.io/twilio-voice-android/docs/5.3.0/)

#### API Changes

- A new `Call.Listener` callback `onCallQualityWarningsChanged()` is introduced.

```java
void onCallQualityWarningsChanged(Call call,
                                  Set<CallQualityWarning> currentWarnings,
                                  Set<CallQualityWarning> previousWarnings);
```

The `Set` that contain the warnings are consisted of `enum` with values of the newly introduced `CallQualityWarning`

```java
public enum CallQualityWarning {
    WARN_HIGH_RTT("high-rtt"),
    WARN_HIGH_JITTER("high-jitter"),
    WARN_HIGH_PACKET_LOSS("high-packet-loss"),
    WARN_LOW_MOS("low-mos"),
    WARN_CONSTANT_AUDIO_IN_LEVEL("constant-audio-input-level"),
}
```

The trigger conditions for the warnings defined in the enumeration are defined as follows:

* `WARN_HIGH_RTT` - Round Trip Time (RTT) > 400 ms for 3 out of last 5 samples.
* `WARN_HIGH_JITTER ` - Jitter > 30 ms for 3 out of last 5 samples.
* `WARN_HIGH_PACKET_LOSS` - Raised when average packet loss > 3% in last 7 samples. Cleared when average packet loss <= 1% in last 7 samples.
* `WARN_LOW_MOS ` - Mean Opinion Score (MOS) < 3.5 for 3 out of last 5 samples.
* `WARN_CONSTANT_AUDIO_IN_LEVEL` - Raised when the standard deviation of audio input levels for last 10 samples is less than or equals 1% of the maximum possible audio input level (32767) i.e. 327.67 and the call is not in the muted state and the call is not on hold. Cleared when the standard deviation of audio input levels for last 10 samples is greater than 3% of the maximum possible audio input level.

- A new method `getCallQualityWarnings()` is added to `Call` to retrieve the present set of call quality related warnings.

- This release also adds the Mean Opinion Score (MOS) measurement `mos` to `RemoteAudioTrackStats`. Use `Call.getStats()` API during a call to retrieve the score. The `mos` is computed once per second. Since the MOS is calculated from network performance measurements, it can be used to indicate the current network condition to the user to provide better usability. See [API Docs](https://twilio.github.io/twilio-voice-android/docs/5.2.0/com/twilio/voice/RemoteAudioTrackStats.html#mos) for more information.

Example:

```java
call.getStats(new StatsListener() {
    @Override
    public void onStats(@NonNull List<StatsReport> statsReports) {
        for (StatsReport statsReport : statsReports) {
            List<RemoteAudioTrackStats> remoteAudioStatsList = statsReport.getRemoteAudioTrackStats();
            for (RemoteAudioTrackStats remoteAudioStats : remoteAudioStatsList) {
                float mos = remoteAudioStats.mos;
            }
        }
    }
});
```

- This release includes support for the expansion of Twilio’s Global Infrastructure via Edge Locations which allows customers to control their connectivity into and out of Twilio’s platform. The Voice Android SDK uses these Edges to connect to Twilio’s infrastructure via the new property `Voice.edge`. This new property supersedes the now deprecated `Voice.region`. See the [new Edge names](https://www.twilio.com/docs/voice/client/regions#regions) and how they map to the old region names.

Here is an example

```java
// Connect using global low latency
Voice.setEdge("roaming")
```
Below are the new methods signatures introduced in `Voice` class.

```
@NonNull public static String getEdge();
public static void setEdge(@NonNull String edge)
```
The following APIs have been deprecated in favor of the new methods.
```
@NonNull public static String getRegion();
public static void setRegion(@NonNull String region)
```
- Added a boolean property `enableIceGatheringOnAnyAddressPorts` in `CallOptions` that allows gathering of ICE candidates from "any address" ports. This allows applications to work in certain VPN environments.

Reference the following code snippet to enable or disable this feature. Note, `enableIceGatheringOnAnyAddressPorts` is disabled by default.

Configure `enableIceGatheringOnAnyAddressPorts` with `ConnectOptions`

```java
ConnectOptions connectOptions = new ConnectOptions.Builder(accessToken)
        .enableIceGatheringOnAnyAddressPorts(iceGatheringOnAnyAddressPorts)
        .build();
Voice.connect(context, connectOptions, callListener);
```

Configure `enableIceGatheringOnAnyAddressPorts` with `AcceptOptions`

```java
AcceptOptions acceptOptions = new AcceptOptions.Builder()
        .enableIceGatheringOnAnyAddressPorts(iceGatheringOnAnyAddressPorts)
        .build();
callInvite.accept(context, acceptOptions, callListener); 
```
- By default ICE gathering is done on all interfaces except some VPN type interfaces. This makes it impossible to connect to Twilio in networks that require the use of VPN. In this release, the new boolean property `enableIceGatheringOnAnyAddressPorts` in `CallOptions` allows the gathering of ICE candidates from all available interfaces. This should be used in those networks where the default does not work. See [AcceptOptions.Builder.enableIceGatheringOnAnyAddressPorts](https://twilio.github.io/twilio-voice-android/docs/5.3.0/com/twilio/voice/AcceptOptions.Builder.html#enableIceGatheringOnAnyAddressPorts-boolean-) or [ConnectOptions.Builder.enableIceGatheringOnAnyAddressPorts](https://twilio.github.io/twilio-voice-android/docs/5.3.0/com/twilio/voice/ConnectOptions.Builder.html#enableIceGatheringOnAnyAddressPorts-boolean-) for more information.

#### Library Size Report

| ABI             | App Size Increase |
| --------------- | ----------------- |
| universal       | 15.2MB          |
| armeabi-v7a     | 3.4MB           |
| arm64-v8a       | 3.9MB           |
| x86             | 4.1MB           |
| x86_64          | 4.1MB           |

#### Things to Note
- Restrictive networks may fail unless ICE servers are provided via `ConnectOptions.Builder.iceOptions(...)` or `AcceptOptions.Builder.iceOptions(...)`. ICE servers can be obtained from [Twilio Network Travarsal Service](https://www.twilio.com/stun-turn).
- Occasional native crash in `AsyncTask` of registration/unregistration and event
publishing. The crash has only been observed on API 18 devices and results from a
thread [safety bug in Android](https://issuetracker.google.com/issues/37002161). Similar crashes
have been reported in the popular networking library OkHttp
[#1520](https://github.com/square/okhttp/issues/1520)
[#1338](https://github.com/square/okhttp/issues/1338). If this bug is impacting your applications,
please open an issue on [our quickstart](https://github.com/twilio/voice-quickstart-android) and
we will investigate potential fixes.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
