### PR TITLE
Upgrade to AudioSwitch 0.1.4

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -69,7 +69,7 @@ android {
 dependencies {
     testImplementation 'junit:junit:4.12'
 
-    implementation 'com.twilio:audioswitch:0.1.3'
+    implementation 'com.twilio:audioswitch:0.1.4'
     implementation 'com.twilio:voice-android:5.3.0'
     implementation 'com.android.support:design:28.0.0'
     implementation 'com.android.support:support-media-compat:28.0.0'


### PR DESCRIPTION
## Description

Upgraded the AudioSwitch dependency to 0.1.4.

### 0.1.4

Enhancements
- AAR minification is now enabled for release artifacts.

Bug Fixes

- Fixed a bug where the audio output doesn't automatically route to a newly connected bluetooth headset.
- Fixed a bug where the selected audio device doesn't get routed back to the default audio device when an error occurs when attempting to connect to a headset.

- [x] I acknowledge that all my contributions will be made under the project's license.
