### PR TITLE
Use Voice Android SDK 5.3.1. Upgraded to AGP 4.0.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -70,7 +70,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 
     implementation 'com.twilio:audioswitch:0.1.3'
-    implementation 'com.twilio:voice-android:5.3.0'
+    implementation 'com.twilio:voice-android:5.3.1'
     implementation 'com.android.support:design:28.0.0'
     implementation 'com.android.support:support-media-compat:28.0.0'
     implementation 'com.android.support:animated-vector-drawable:28.0.0'

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.0'
+        classpath 'com.android.tools.build:gradle:4.0.0'
         classpath 'com.google.gms:google-services:4.2.0'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/exampleCustomAudioDevice/build.gradle
+++ b/exampleCustomAudioDevice/build.gradle
@@ -45,7 +45,7 @@ android {
 dependencies {
     testImplementation 'junit:junit:4.12'
 
-    implementation 'com.twilio:voice-android:5.3.0'
+    implementation 'com.twilio:voice-android:5.3.1'
     implementation 'com.android.support:design:28.0.0'
     implementation 'com.android.support:support-media-compat:28.0.0'
     implementation 'com.android.support:animated-vector-drawable:28.0.0'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Feb 24 14:54:56 PST 2020
+#Tue Jun 23 02:01:23 PDT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip


### PR DESCRIPTION
* This PR uses the Voice Android SDK 5.3.1.
* Upgraded to AGP 4.0

### 5.3.1

June 23rd, 2020

* Programmable Voice Android SDK 5.3.1 [[bintray]](https://bintray.com/twilio/releases/voice-android/5.3.1), [[docs]](https://twilio.github.io/twilio-voice-android/docs/5.3.1/)

#### Bug Fixes 

- Fixed a bug in `Voice.setRegion(..)` API that disallowed to use non default values.

#### Library Size Report

| ABI             | App Size Increase |
| --------------- | ----------------- |
| universal       | 15.2MB          |
| armeabi-v7a     | 3.4MB           |
| arm64-v8a       | 3.9MB           |
| x86             | 4.1MB           |
| x86_64          | 4.1MB           |

#### Things to Note
- Restrictive networks may fail unless ICE servers are provided via `ConnectOptions.Builder.iceOptions(...)` or `AcceptOptions.Builder.iceOptions(...)`. ICE servers can be obtained from [Twilio Network Travarsal Service](https://www.twilio.com/stun-turn).
- Occasional native crash in `AsyncTask` of registration/unregistration and event
publishing. The crash has only been observed on API 18 devices and results from a
thread [safety bug in Android](https://issuetracker.google.com/issues/37002161). Similar crashes
have been reported in the popular networking library OkHttp
[#1520](https://github.com/square/okhttp/issues/1520)
[#1338](https://github.com/square/okhttp/issues/1338). If this bug is impacting your applications,
please open an issue on [our quickstart](https://github.com/twilio/voice-quickstart-android) and
we will investigate potential fixes.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
