### PR TITLE
Use Voice Android  5.4.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -70,7 +70,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 
     implementation 'com.twilio:audioswitch:0.1.5'
-    implementation 'com.twilio:voice-android:5.3.1'
+    implementation 'com.twilio:voice-android:5.4.0'
     implementation 'com.android.support:design:28.0.0'
     implementation 'com.android.support:support-media-compat:28.0.0'
     implementation 'com.android.support:animated-vector-drawable:28.0.0'

--- a/app/src/main/java/com/twilio/voice/quickstart/VoiceActivity.java
+++ b/app/src/main/java/com/twilio/voice/quickstart/VoiceActivity.java
@@ -483,7 +483,7 @@ public class VoiceActivity extends AppCompatActivity {
         alertDialogBuilder.setTitle("Incoming Call");
         alertDialogBuilder.setPositiveButton("Accept", answerCallClickListener);
         alertDialogBuilder.setNegativeButton("Reject", cancelClickListener);
-        alertDialogBuilder.setMessage(callInvite.getFrom() + " is calling.");
+        alertDialogBuilder.setMessage(callInvite.getFrom() + " is calling wth " + callInvite.getCallerInfo().isVerified() + " status");
         return alertDialogBuilder.create();
     }
 

--- a/app/src/main/java/com/twilio/voice/quickstart/VoiceActivity.java
+++ b/app/src/main/java/com/twilio/voice/quickstart/VoiceActivity.java
@@ -483,7 +483,7 @@ public class VoiceActivity extends AppCompatActivity {
         alertDialogBuilder.setTitle("Incoming Call");
         alertDialogBuilder.setPositiveButton("Accept", answerCallClickListener);
         alertDialogBuilder.setNegativeButton("Reject", cancelClickListener);
-        alertDialogBuilder.setMessage(callInvite.getFrom() + " is calling wth " + callInvite.getCallerInfo().isVerified() + " status");
+        alertDialogBuilder.setMessage(callInvite.getFrom() + " is calling with " + callInvite.getCallerInfo().isVerified() + " status");
         return alertDialogBuilder.create();
     }
 

--- a/exampleCustomAudioDevice/build.gradle
+++ b/exampleCustomAudioDevice/build.gradle
@@ -45,7 +45,7 @@ android {
 dependencies {
     testImplementation 'junit:junit:4.12'
 
-    implementation 'com.twilio:voice-android:5.3.1'
+    implementation 'com.twilio:voice-android:5.4.0'
     implementation 'com.android.support:design:28.0.0'
     implementation 'com.android.support:support-media-compat:28.0.0'
     implementation 'com.android.support:animated-vector-drawable:28.0.0'


### PR DESCRIPTION
### 5.4.0

July 9th, 2020

* Programmable Voice Android SDK 5.4.0 [[bintray]](https://bintray.com/twilio/releases/voice-android/5.4.0), [[docs]](https://twilio.github.io/twilio-voice-android/docs/5.4.0/)

### API Change

- A `CallerInfo` object is introduced to represent information about the caller. Currently, this information is limited to SHAKEN/STIR status of incoming PSTN Calls, but may later be expanded to include CNAM, and other endpoint types. `isVerified` attribute represents whether or not the caller's phone number has been verified by Twilio using SHAKEN/STIR validation. The value of this attribute is `true` if the caller has been validated at 'A' level, `false` if the caller has been verified at any lower level or has failed validation. If SHAKEN/STIR information is unavilable for the caller or stir status value is `null`, the value of this attribute will be `null`.

- `CallInvite` class includes `getCallerInfo(..)` method that returns the `CallerInfo` of the caller.

For details on how Twilio uses SHAKEN/STIR to make trusted calls and protect against unlawful spoofing, please visit [here](https://www.twilio.com/docs/voice/trusted-calling-using-shakenstir).

#### Bug Fixes

- Fixed crash bugs during teardown of a `Call`.

#### Library Size Report

| ABI             | App Size Increase |
| --------------- | ----------------- |
| universal       | 15.2MB          |
| armeabi-v7a     | 3.4MB           |
| arm64-v8a       | 3.9MB           |
| x86             | 4.1MB           |
| x86_64          | 4.1MB           |

#### Things to Note
- Restrictive networks may fail unless ICE servers are provided via `ConnectOptions.Builder.iceOptions(...)` or `AcceptOptions.Builder.iceOptions(...)`. ICE servers can be obtained from [Twilio Network Travarsal Service](https://www.twilio.com/stun-turn).
- Occasional native crash in `AsyncTask` of registration/unregistration and event
publishing. The crash has only been observed on API 18 devices and results from a
thread [safety bug in Android](https://issuetracker.google.com/issues/37002161). Similar crashes
have been reported in the popular networking library OkHttp
[#1520](https://github.com/square/okhttp/issues/1520)
[#1338](https://github.com/square/okhttp/issues/1338). If this bug is impacting your applications,
please open an issue on [our quickstart](https://github.com/twilio/voice-quickstart-android) and
we will investigate potential fixes.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
