### PR TITLE
Consume Voice Android 5.4.2

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -70,7 +70,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 
     implementation 'com.twilio:audioswitch:1.0.0'
-    implementation 'com.twilio:voice-android:5.4.1'
+    implementation 'com.twilio:voice-android:5.4.2'
     implementation 'com.android.support:design:28.0.0'
     implementation 'com.android.support:support-media-compat:28.0.0'
     implementation 'com.android.support:animated-vector-drawable:28.0.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -70,7 +70,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 
     implementation 'com.twilio:audioswitch:1.0.0'
-    implementation 'com.twilio:voice-android:5.4.0'
+    implementation 'com.twilio:voice-android:5.4.1'
     implementation 'com.android.support:design:28.0.0'
     implementation 'com.android.support:support-media-compat:28.0.0'
     implementation 'com.android.support:animated-vector-drawable:28.0.0'

--- a/exampleCustomAudioDevice/build.gradle
+++ b/exampleCustomAudioDevice/build.gradle
@@ -45,7 +45,7 @@ android {
 dependencies {
     testImplementation 'junit:junit:4.12'
 
-    implementation 'com.twilio:voice-android:5.4.0'
+    implementation 'com.twilio:voice-android:5.4.1'
     implementation 'com.android.support:design:28.0.0'
     implementation 'com.android.support:support-media-compat:28.0.0'
     implementation 'com.android.support:animated-vector-drawable:28.0.0'

--- a/exampleCustomAudioDevice/build.gradle
+++ b/exampleCustomAudioDevice/build.gradle
@@ -45,7 +45,7 @@ android {
 dependencies {
     testImplementation 'junit:junit:4.12'
 
-    implementation 'com.twilio:voice-android:5.4.1'
+    implementation 'com.twilio:voice-android:5.4.2'
     implementation 'com.android.support:design:28.0.0'
     implementation 'com.android.support:support-media-compat:28.0.0'
     implementation 'com.android.support:animated-vector-drawable:28.0.0'


### PR DESCRIPTION
### 5.4.2

September 14th, 2020

* Programmable Voice Android SDK 5.4.1 [[bintray]](https://bintray.com/twilio/releases/voice-android/5.4.2), [[docs]](https://twilio.github.io/twilio-voice-android/docs/5.4.2/)

#### Bug Fixes

- Fixed a crash bug when processing empty stats reports or stats reports without remote audio tracks.

#### Library Size Report

| ABI             | App Size Increase |
| --------------- | ----------------- |
| universal       | 15.3MB          |
| armeabi-v7a     | 3.4MB           |
| arm64-v8a       | 3.9MB           |
| x86             | 4.1MB           |
| x86_64          | 4.2MB           |

#### Things to Note
- Restrictive networks may fail unless ICE servers are provided via `ConnectOptions.Builder.iceOptions(...)` or `AcceptOptions.Builder.iceOptions(...)`. ICE servers can be obtained from [Twilio Network Travarsal Service](https://www.twilio.com/stun-turn).
- Occasional native crash in `AsyncTask` of registration/unregistration and event
publishing. The crash has only been observed on API 18 devices and results from a
thread [safety bug in Android](https://issuetracker.google.com/issues/37002161). Similar crashes
have been reported in the popular networking library OkHttp
[#1520](https://github.com/square/okhttp/issues/1520)
[#1338](https://github.com/square/okhttp/issues/1338). If this bug is impacting your applications,
please open an issue on [our quickstart](https://github.com/twilio/voice-quickstart-android) and
we will investigate potential fixes.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
