### PR TITLE
Consume Android Voice SDK 5.5.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -70,7 +70,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 
     implementation 'com.twilio:audioswitch:1.0.0'
-    implementation 'com.twilio:voice-android:5.4.2'
+    implementation 'com.twilio:voice-android:5.5.0'
     implementation 'com.android.support:design:28.0.0'
     implementation 'com.android.support:support-media-compat:28.0.0'
     implementation 'com.android.support:animated-vector-drawable:28.0.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -70,7 +70,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 
     implementation 'com.twilio:audioswitch:1.0.0'
-    implementation 'com.twilio:voice-android:5.4.0'
+    implementation 'com.twilio:voice-android:5.4.1'
     implementation 'com.android.support:design:28.0.0'
     implementation 'com.android.support:support-media-compat:28.0.0'
     implementation 'com.android.support:animated-vector-drawable:28.0.0'

--- a/exampleCustomAudioDevice/build.gradle
+++ b/exampleCustomAudioDevice/build.gradle
@@ -45,7 +45,7 @@ android {
 dependencies {
     testImplementation 'junit:junit:4.12'
 
-    implementation 'com.twilio:voice-android:5.4.0'
+    implementation 'com.twilio:voice-android:5.4.1'
     implementation 'com.android.support:design:28.0.0'
     implementation 'com.android.support:support-media-compat:28.0.0'
     implementation 'com.android.support:animated-vector-drawable:28.0.0'

--- a/exampleCustomAudioDevice/build.gradle
+++ b/exampleCustomAudioDevice/build.gradle
@@ -45,7 +45,7 @@ android {
 dependencies {
     testImplementation 'junit:junit:4.12'
 
-    implementation 'com.twilio:voice-android:5.4.2'
+    implementation 'com.twilio:voice-android:5.5.0'
     implementation 'com.android.support:design:28.0.0'
     implementation 'com.android.support:support-media-compat:28.0.0'
     implementation 'com.android.support:animated-vector-drawable:28.0.0'

--- a/exampleCustomAudioDevice/src/main/java/com/twilio/examplecustomaudiodevice/FileAndMicAudioDevice.java
+++ b/exampleCustomAudioDevice/src/main/java/com/twilio/examplecustomaudiodevice/FileAndMicAudioDevice.java
@@ -133,7 +133,7 @@ public class FileAndMicAudioDevice implements AudioDevice {
             AudioDevice.audioDeviceReadRenderData(renderingAudioDeviceContext, readByteBuffer);
 
             int bytesWritten = 0;
-            if (WebRtcAudioUtils.runningOnLollipopOrHigher()) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                 bytesWritten = writeOnLollipop(audioTrack, readByteBuffer, readByteBuffer.capacity());
             } else {
                 bytesWritten = writePreLollipop(audioTrack, readByteBuffer, readByteBuffer.capacity());


### PR DESCRIPTION
### 5.5.0

September 16th, 2020

* Programmable Voice Android SDK 5.5.0 [[bintray]](https://bintray.com/twilio/releases/voice-android/5.5.0), [[docs]](https://twilio.github.io/twilio-voice-android/docs/5.5.0/)

#### Enhancements

* The Voice Android SDK uses Chromium WebRTC 83.
* The Voice Android SDK is built with NDK r20b. 
* PeerConnection state is now reported to Insights.
* `mos` calculation algorithm has been updated to make it monotonically decreasing with increasing `jitter` and `packets-lost-fraction` values over a range of `rtt` values. The final mos should always be in the range [1.0, 4.6].

| Event Group | Level | Event Name | Description |
|-------------|-------|------------|-------------|
| pc-connection-state| DEBUG | new | Raised when peer connection state is new |
| pc-connection-state| DEBUG | connecting | Raised when peer connection state is connecting |
| pc-connection-state| DEBUG | connected | Raised when peer connection state is connected |
| pc-connection-state| DEBUG | disconnected | Raised when peer connection state is disconnected |
| pc-connection-state| ERROR | failed | Raised when peer connection state is failed |
| pc-connection-state| DEBUG | closed | Raised when peer connection state is closed |

* A new Insights event `selected-ice-candidate-pair` is reported with the active local ICE candidate and remote ICE candidate.

| Event Group | Level | Event Name | Description |
|-------------|-------|------------|-------------|
| ice-candidate | DEBUG | selected-ice-candidate-pair | Raised when the active local and remote ICE candidates of the peer connection are determined |


* Defined new error code

| Error Codes | ErrorCode  | Error Message |
| ------------| -----------| ------------- |
| 53407       | EXCEPTION_MEDIA_DTLS_TRANSPORT_FAILED | Media connection failed due to DTLS handshake failure |

#### Maintenance

- A security patch has been applied to prevent host candidate DNS attacks. See [https://bugs.chromium.org/p/webrtc/issues/detail?id=11597] for details.

#### Bug Fixes

- Fixed a crash bug when processing empty stats reports or stats reports without remote audio tracks.

##### SDK Size Update

The table below highlights the updated App Size Impact.

| ABI             | App Size Impact 5.3.0  | App Size Impact 5.5.0    |
| --------------- | ---------------------- |--------------------------|
| universal       | 15.2MB                 | 14.3MB                   |
| armeabi-v7a     | 3.3MB                  | 3.2MB                    |
| arm64-v8a       | 3.8MB                  | 3.7MB                    |
| x86             | 4MB                    | 3.9MB                    |
| x86_64          | 4.1MB                  | 3.8MB                    |

#### Library Size Report

| ABI             | App Size Increase |
| --------------- | ----------------- |
| universal       | 14.3MB          |
| armeabi-v7a     | 3.2MB           |
| arm64-v8a       | 3.7MB           |
| x86             | 3.9MB           |
| x86_64          | 3.8MB           |

#### Things to Note
- Restrictive networks may fail unless ICE servers are provided via `ConnectOptions.Builder.iceOptions(...)` or `AcceptOptions.Builder.iceOptions(...)`. ICE servers can be obtained from [Twilio Network Travarsal Service](https://www.twilio.com/stun-turn).
- Occasional native crash in `AsyncTask` of registration/unregistration and event
publishing. The crash has only been observed on API 18 devices and results from a
thread [safety bug in Android](https://issuetracker.google.com/issues/37002161). Similar crashes
have been reported in the popular networking library OkHttp
[#1520](https://github.com/square/okhttp/issues/1520)
[#1338](https://github.com/square/okhttp/issues/1338). If this bug is impacting your applications,
please open an issue on [our quickstart](https://github.com/twilio/voice-quickstart-android) and
we will investigate potential fixes.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
