### PR TITLE
Consume Voice Android SDK 5.6.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,17 +21,17 @@ ext.playCustomRingback = {
 }
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion versions.compileSdk
 
     compileOptions {
-        sourceCompatibility 1.8
-        targetCompatibility 1.8
+        sourceCompatibility versions.java
+        targetCompatibility versions.java
     }
 
     defaultConfig {
         applicationId "com.twilio.voice.quickstart"
-        minSdkVersion 16
-        targetSdkVersion 30
+        minSdkVersion versions.minSdk
+        targetSdkVersion versions.targetSdk
         versionCode 1
         versionName "1.0"
     }
@@ -67,19 +67,17 @@ android {
 }
 
 dependencies {
-    testImplementation 'junit:junit:4.12'
-
-    implementation 'com.twilio:audioswitch:1.0.0'
-    implementation 'com.twilio:voice-android:5.5.0'
-    implementation 'com.android.support:design:30.0.0'
-    implementation 'com.android.support:support-media-compat:30.0.0'
-    implementation 'com.android.support:animated-vector-drawable:30.0.0'
-    implementation 'com.android.support:support-v4:30.0.0'
-    implementation 'com.squareup.retrofit:retrofit:1.9.0'
-    implementation 'com.koushikdutta.ion:ion:2.1.8'
-    implementation 'com.google.firebase:firebase-messaging:17.6.0'
-    implementation 'androidx.lifecycle:lifecycle-extensions:2.1.0'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    implementation "com.twilio:audioswitch:${versions.audioSwitch}"
+    implementation "com.twilio:voice-android:${versions.voiceAndroid}"
+    implementation "com.android.support:design:${versions.supportLibrary}"
+    implementation "com.android.support:support-media-compat:${versions.supportLibrary}"
+    implementation "com.android.support:animated-vector-drawable:${versions.supportLibrary}"
+    implementation "com.android.support:appcompat-v7:${versions.supportLibrary}"
+    implementation "com.squareup.retrofit2:retrofit:${versions.retrofit}"
+    implementation "com.koushikdutta.ion:ion:${versions.ion}"
+    implementation "com.google.firebase:firebase-messaging:${versions.firebase}"
+    implementation "androidx.lifecycle:lifecycle-extensions:${versions.androidxLifecycle}"
+    androidTestImplementation "androidx.test.ext:junit:${versions.junit}"
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,26 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
+
+    ext.versions = [
+            'java'               : JavaVersion.VERSION_1_8,
+            'androidGradlePlugin': '4.0.1',
+            'googleServices'     : '4.2.0',
+            'compileSdk'         : 30,
+            'buildTools'         : '28.0.3',
+            'minSdk'             : 16,
+            'targetSdk'          : 30,
+            'supportLibrary'     : '30.0.0',
+            'firebase'           : '17.6.0',
+            'retrofit'           : '2.0.0-beta4',
+            'okhttp'             : '3.6.0',
+            'ion'                : '2.1.8',
+            'voiceAndroid'       : '5.6.0',
+            'audioSwitch'        : '1.0.1',
+            'androidxLifecycle'  : '2.2.0',
+            'junit'              : '1.1.1'
+    ]
+
     repositories {
         jcenter()
         maven {
@@ -10,8 +30,8 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.0'
-        classpath 'com.google.gms:google-services:4.2.0'
+        classpath "com.android.tools.build:gradle:${versions.androidGradlePlugin}"
+        classpath "com.google.gms:google-services:${versions.googleServices}"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/exampleCustomAudioDevice/build.gradle
+++ b/exampleCustomAudioDevice/build.gradle
@@ -1,17 +1,17 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion versions.compileSdk
 
     compileOptions {
-        sourceCompatibility 1.8
-        targetCompatibility 1.8
+        sourceCompatibility versions.java
+        targetCompatibility versions.java
     }
 
     defaultConfig {
         applicationId "com.twilio.examplecustomaudiodevice"
-        minSdkVersion 16
-        targetSdkVersion 30
+        minSdkVersion versions.minSdk
+        targetSdkVersion versions.targetSdk
         versionCode 1
         versionName "1.0"
     }
@@ -43,16 +43,13 @@ android {
 }
 
 dependencies {
-    testImplementation 'junit:junit:4.12'
-
-    implementation 'com.twilio:voice-android:5.5.0'
-    implementation 'com.android.support:design:30.0.0'
-    implementation 'com.android.support:support-media-compat:30.0.0'
-    implementation 'com.android.support:animated-vector-drawable:30.0.0'
-    implementation 'com.android.support:support-v4:30.0.0'
-    implementation 'com.squareup.retrofit:retrofit:1.9.0'
-    implementation 'com.koushikdutta.ion:ion:2.1.8'
-    implementation 'com.google.firebase:firebase-messaging:17.6.0'
-    implementation 'androidx.lifecycle:lifecycle-extensions:2.1.0'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    implementation "com.twilio:voice-android:${versions.voiceAndroid}"
+    implementation "com.android.support:design:${versions.supportLibrary}"
+    implementation "com.android.support:support-media-compat:${versions.supportLibrary}"
+    implementation "com.android.support:animated-vector-drawable:${versions.supportLibrary}"
+    implementation "com.android.support:appcompat-v7:${versions.supportLibrary}"
+    implementation "com.squareup.retrofit2:retrofit:${versions.retrofit}"
+    implementation "com.koushikdutta.ion:ion:${versions.ion}"
+    implementation "androidx.lifecycle:lifecycle-extensions:${versions.androidxLifecycle}"
+    androidTestImplementation "androidx.test.ext:junit:${versions.junit}"
 }


### PR DESCRIPTION
### 5.6.0

September 29th, 2020

* Programmable Voice Android SDK 5.6.0 [[bintray]](https://bintray.com/twilio/releases/voice-android/5.6.0), [[docs]](https://twilio.github.io/twilio-voice-android/docs/5.6.0/)


#### Maintenance

- The SDK compileSDKVersion and targetSDKVersion were updated to 30 from 28. No changes are required to migrate to this version in an existing application.

#### Library Size Report

| ABI             | App Size Increase |
| --------------- | ----------------- |
| universal       | 15.3MB          |
| armeabi-v7a     | 3.4MB           |
| arm64-v8a       | 3.9MB           |
| x86             | 4.1MB           |
| x86_64          | 4.2MB           |

#### Things to Note
- Restrictive networks may fail unless ICE servers are provided via `ConnectOptions.Builder.iceOptions(...)` or `AcceptOptions.Builder.iceOptions(...)`. ICE servers can be obtained from [Twilio Network Travarsal Service](https://www.twilio.com/stun-turn).
- Occasional native crash in `AsyncTask` of registration/unregistration and event
publishing. The crash has only been observed on API 18 devices and results from a
thread [safety bug in Android](https://issuetracker.google.com/issues/37002161). Similar crashes
have been reported in the popular networking library OkHttp
[#1520](https://github.com/square/okhttp/issues/1520)
[#1338](https://github.com/square/okhttp/issues/1338). If this bug is impacting your applications,
please open an issue on [our quickstart](https://github.com/twilio/voice-quickstart-android) and
we will investigate potential fixes.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
