### PR TITLE
Use Voice Android SDK 5.6.1. Upgraded AGP to 4.1.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
 
     ext.versions = [
             'java'               : JavaVersion.VERSION_1_8,
-            'androidGradlePlugin': '4.0.1',
+            'androidGradlePlugin': '4.1.1',
             'googleServices'     : '4.2.0',
             'compileSdk'         : 30,
             'buildTools'         : '28.0.3',
@@ -15,7 +15,7 @@ buildscript {
             'retrofit'           : '2.0.0-beta4',
             'okhttp'             : '3.6.0',
             'ion'                : '2.1.8',
-            'voiceAndroid'       : '5.6.0',
+            'voiceAndroid'       : '5.6.1',
             'audioSwitch'        : '1.1.0',
             'androidxLifecycle'  : '2.2.0',
             'junit'              : '1.1.1'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Jun 23 02:01:23 PDT 2020
+#Tue Jan 05 10:26:05 PST 2021
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip


### PR DESCRIPTION
### 5.6.1

January 5th, 2021

* Programmable Voice Android SDK 5.6.1 [[bintray]](https://bintray.com/twilio/releases/voice-android/5.6.1), [[docs]](https://twilio.github.io/twilio-voice-android/docs/5.6.1/)

#### Bug Fixes

- Fixed a bug where caller did not receive the `onDisconnected` callback with error when the callee hung up. 
- Fixed a bug where callee did not receive the `onCancelledCallInvite` callback with error when signaling connection error happened.

#### Enhancements

- Private IP addresses are masked in Release mode for the SDK logs and the `ice-candidate` Insights event payload.
- Private IP addresses will not be masked in `Debug` mode. The `selected-ice-candidate-pair` event will contain private IP address of the local active ICE candidate for debugging purpose in both Release and Debug modes.
- Stop publishing Voice Insights event with invalid access token. 

#### Library Size Report

| ABI             | App Size Increase |
| --------------- | ----------------- |
| universal       | 15.3MB          |
| armeabi-v7a     | 3.4MB           |
| arm64-v8a       | 3.9MB           |
| x86             | 4.1MB           |
| x86_64          | 4.2MB           |

#### Things to Note
- Restrictive networks may fail unless ICE servers are provided via `ConnectOptions.Builder.iceOptions(...)` or `AcceptOptions.Builder.iceOptions(...)`. ICE servers can be obtained from [Twilio Network Travarsal Service](https://www.twilio.com/stun-turn).
- Occasional native crash in `AsyncTask` of registration/unregistration and event
publishing. The crash has only been observed on API 18 devices and results from a
thread [safety bug in Android](https://issuetracker.google.com/issues/37002161). Similar crashes
have been reported in the popular networking library OkHttp
[#1520](https://github.com/square/okhttp/issues/1520)
[#1338](https://github.com/square/okhttp/issues/1338). If this bug is impacting your applications,
please open an issue on [our quickstart](https://github.com/twilio/voice-quickstart-android) and
we will investigate potential fixes.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
