### PR TITLE
Updated ion to use 3.1.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -73,7 +73,6 @@ dependencies {
     implementation "com.android.support:support-media-compat:${versions.supportLibrary}"
     implementation "com.android.support:animated-vector-drawable:${versions.supportLibrary}"
     implementation "com.android.support:appcompat-v7:${versions.supportLibrary}"
-    implementation "com.squareup.retrofit2:retrofit:${versions.retrofit}"
     implementation "com.koushikdutta.ion:ion:${versions.ion}"
     implementation "com.google.firebase:firebase-messaging:${versions.firebase}"
     implementation "androidx.lifecycle:lifecycle-extensions:${versions.androidxLifecycle}"

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -5,12 +5,4 @@
 -keep class com.twilio.voice.** { *; }
 -keepattributes InnerClasses
 
-# Retrofit
--dontwarn okio.**
--dontwarn retrofit.**
--keep class retrofit.** { *; }
--keepclassmembers,allowobfuscation interface * {
-    @retrofit.http.** <methods>;
-}
-
 -dontwarn com.squareup.okhttp.**

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
             'firebase'           : '17.6.0',
             'retrofit'           : '2.0.0-beta4',
             'okhttp'             : '3.6.0',
-            'ion'                : '2.1.8',
+            'ion'                : '3.1.0',
             'voiceAndroid'       : '5.6.2',
             'audioSwitch'        : '1.1.0',
             'androidxLifecycle'  : '2.2.0',

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,6 @@ buildscript {
             'targetSdk'          : 30,
             'supportLibrary'     : '30.0.0',
             'firebase'           : '17.6.0',
-            'retrofit'           : '2.0.0-beta4',
             'okhttp'             : '3.6.0',
             'ion'                : '3.1.0',
             'voiceAndroid'       : '5.6.2',

--- a/exampleCustomAudioDevice/build.gradle
+++ b/exampleCustomAudioDevice/build.gradle
@@ -48,7 +48,6 @@ dependencies {
     implementation "com.android.support:support-media-compat:${versions.supportLibrary}"
     implementation "com.android.support:animated-vector-drawable:${versions.supportLibrary}"
     implementation "com.android.support:appcompat-v7:${versions.supportLibrary}"
-    implementation "com.squareup.retrofit2:retrofit:${versions.retrofit}"
     implementation "com.koushikdutta.ion:ion:${versions.ion}"
     implementation "androidx.lifecycle:lifecycle-extensions:${versions.androidxLifecycle}"
     androidTestImplementation "androidx.test.ext:junit:${versions.junit}"


### PR DESCRIPTION
Updated ion to use 3.1.0. The issues was reported here https://github.com/twilio/voice-quickstart-android/issues/405, thanks @EMChamp.  [This](https://github.com/koush/ion/issues/939) was fixed in version 3.1.0.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
