### PR TITLE
Consume Voice Android SDK 5.6.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
             'supportLibrary'     : '30.0.0',
             'firebase'           : '17.6.0',
             'okhttp'             : '3.6.0',
-            'voiceAndroid'       : '5.6.2',
+            'voiceAndroid'       : '5.6.3',
             'audioSwitch'        : '1.1.2',
             'androidxLifecycle'  : '2.2.0',
             'junit'              : '1.1.1'


### PR DESCRIPTION
### 5.6.3

March 11, 2021

* Programmable Voice Android SDK 5.6.3 [[bintray]](https://bintray.com/twilio/releases/voice-android/5.6.3), [[docs]](https://twilio.github.io/twilio-voice-android/docs/5.6.3/)

#### Bug Fixes

- Fixed a potential bug in the core module where the Logger could be accessed after being destroyed by another thread. 

#### Library size report

Size Report

| ABI             | APK Size Impact |
| --------------- | --------------- |
| x86             | 3.9MB           |
| x86_64          | 3.9MB           |
| armeabi-v7a     | 3.2MB           |
| arm64-v8a       | 3.7MB           |
| universal       | 14.4MB          |

#### Things to note

- Restrictive networks may fail unless ICE servers are provided via `ConnectOptions.Builder.iceOptions(...)` or `AcceptOptions.Builder.iceOptions(...)`. ICE servers can be obtained from [Twilio Network Traversal Service](https://www.twilio.com/stun-turn).
- Occasional native crash in `AsyncTask` of registration/unregistration and event
publishing. The crash has only been observed on API 18 devices and results from a
thread [safety bug in Android](https://issuetracker.google.com/issues/37002161). Similar crashes
have been reported in the popular networking library OkHttp
[#1520](https://github.com/square/okhttp/issues/1520)
[#1338](https://github.com/square/okhttp/issues/1338). If this bug is impacting your applications,
please open an issue on [our quickstart](https://github.com/twilio/voice-quickstart-android) and
we will investigate potential fixes.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
