### PR TITLE
Change README header to h2.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Twilio Voice Quickstart for Android
+## Twilio Voice Quickstart for Android
 
 > NOTE: This sample application uses the Programmable Voice Android 5.x APIs. If you are using prior versions of the SDK, we highly recommend planning your migration to 5.0 as soon as possible.
 


### PR DESCRIPTION
Trivial: Change first header in README to `<h2>`, because the docs platform only supports `<h2>` and below for text on the page (for accessibility reasons -- there should only be one h1 on a page).

The iOS tutorial already does this: https://raw.githubusercontent.com/twilio/voice-quickstart-ios/master/README.md

Current formatting:

<img width="1045" alt="Screen Shot 2021-03-23 at 8 11 05 AM" src="https://user-images.githubusercontent.com/13165465/112169431-6b42a700-8baf-11eb-8201-503616725191.png">


With `<h2>` applied: 

<img width="933" alt="Screen Shot 2021-03-23 at 8 11 33 AM" src="https://user-images.githubusercontent.com/13165465/112169444-6e3d9780-8baf-11eb-86cc-ffe87d7922fc.png">



**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
