### PR TITLE
Consume Voice Android SDK 5.7.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
             'supportLibrary'     : '30.0.0',
             'firebase'           : '17.6.0',
             'okhttp'             : '3.6.0',
-            'voiceAndroid'       : '5.6.3',
+            'voiceAndroid'       : '5.7.1',
             'audioSwitch'        : '1.1.2',
             'androidxLifecycle'  : '2.2.0',
             'junit'              : '1.1.1'

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
             'supportLibrary'     : '30.0.0',
             'firebase'           : '17.6.0',
             'okhttp'             : '3.6.0',
-            'voiceAndroid'       : '5.7.1',
+            'voiceAndroid'       : '5.7.2',
             'audioSwitch'        : '1.1.2',
             'androidxLifecycle'  : '2.2.0',
             'junit'              : '1.1.1'

--- a/build.gradle
+++ b/build.gradle
@@ -39,8 +39,8 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
         mavenCentral()
+        jcenter()
         maven {
             url 'https://maven.google.com/'
             name 'Google'


### PR DESCRIPTION
Consume Voice Android SDK 5.7.2.

### 5.7.2 

March 29, 2021

* Programmable Voice Android SDK 5.7.2[[Maven Central]](https://search.maven.org/artifact/com.twilio/voice-android/5.7.2/aar), [[docs]](https://twilio.github.io/twilio-voice-android/docs/5.7.2/) MD5 Checksum : cac4a963814637b23e2d1ffadda30036

#### Enhancements
- Voice Adnroid artifacts are now published to `MavenCentral` instead of `Bintray`.
    - Ensure to include `mavenCentral()` listed in your project's buildscript repositories section:
   
      ```groovy
      buildscript {
          repositories {
              mavenCentral()
              ...
          }
      }
      ```
- Voice Android SDK now publishes the checksum in the release notes.

#### Bug Fixes

- Fixed a crash when `onNetworkChanged` was called during the teardown process.

#### Things to Note
- Restrictive networks may fail unless ICE servers are provided via `ConnectOptions.Builder.iceOptions(...)` or `AcceptOptions.Builder.iceOptions(...)`. ICE servers can be obtained from [Twilio Network Travarsal Service](https://www.twilio.com/stun-turn).
- Occasional native crash in `AsyncTask` of registration/unregistration and event
publishing. The crash has only been observed on API 18 devices and results from a
thread [safety bug in Android](https://issuetracker.google.com/issues/37002161). Similar crashes
have been reported in the popular networking library OkHttp
[#1520](https://github.com/square/okhttp/issues/1520)
[#1338](https://github.com/square/okhttp/issues/1338). If this bug is impacting your applications,
please open an issue on [our quickstart](https://github.com/twilio/voice-quickstart-android) and
we will investigate potential fixes.

#### Library size report

| ABI             | APK Size Impact |
| --------------- | --------------- |
| x86             | 3.9MB           |
| x86_64          | 3.9MB           |
| armeabi-v7a     | 3.2MB           |
| arm64-v8a       | 3.7MB           |
| universal       | 14.4MB          |
