### PR TITLE
Use Voice Android SDK 5.8.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
             'supportLibrary'     : '30.0.0',
             'firebase'           : '17.6.0',
             'okhttp'             : '3.6.0',
-            'voiceAndroid'       : '5.7.2',
+            'voiceAndroid'       : '5.8.0',
             'audioSwitch'        : '1.1.2',
             'androidxLifecycle'  : '2.2.0',
             'junit'              : '1.1.1'


### PR DESCRIPTION
Consume Voice Android SDK 5.8.0.

### 5.8.0 

May 24, 2021

* Programmable Voice Android SDK 5.8.0[[Maven Central]](https://search.maven.org/artifact/com.twilio/voice-android/5.8.0/aar), [[docs]](https://twilio.github.io/twilio-voice-android/docs/5.8.0/) MD5 Checksum : dff5963249ff07f1378cd322fd50b50b

#### Enhancements
* This release is based on Chromium WebRTC 88.
* The SDK uses Unified Plan SDP semantics instead of Plan-B.

#### Things to Note
- Restrictive networks may fail unless ICE servers are provided via `ConnectOptions.Builder.iceOptions(...)` or `AcceptOptions.Builder.iceOptions(...)`. ICE servers can be obtained from [Twilio Network Travarsal Service](https://www.twilio.com/stun-turn).
- Occasional native crash in `AsyncTask` of registration/unregistration and event
publishing. The crash has only been observed on API 18 devices and results from a
thread [safety bug in Android](https://issuetracker.google.com/issues/37002161). Similar crashes
have been reported in the popular networking library OkHttp
[#1520](https://github.com/square/okhttp/issues/1520)
[#1338](https://github.com/square/okhttp/issues/1338). If this bug is impacting your applications,
please open an issue on [our quickstart](https://github.com/twilio/voice-quickstart-android) and
we will investigate potential fixes.

#### Library size report

| ABI             | APK Size Impact |
| --------------- | --------------- |
| x86             | 4MB             |
| x86_64          | 3.9MB           |
| armeabi-v7a     | 3.3MB           |
| arm64-v8a       | 3.8MB           |
| universal       | 14.8MB          |


**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
