### PR TITLE
Remove callback(null, null) at the end to avoid returning before the call is created

### DIFF
--- a/Server/functions/place-call.js
+++ b/Server/functions/place-call.js
@@ -49,8 +49,6 @@ exports.handler = function(context, event, callback) {
       }
     });
   }
-
-  callback(null, null);
 };
 
 function isNumber(to) {


### PR DESCRIPTION
Remove callback(null, null) at the end to avoid returning before the call is created

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
