### PR TITLE
Use Voice SDK 6.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Twilio Voice Quickstart for Android
 
-> NOTE: This sample application uses the Programmable Voice Android 5.x APIs. If you are using prior versions of the SDK, we highly recommend planning your migration to 5.0 as soon as possible.
+> NOTE: This sample application uses the Programmable Voice Android 6.x APIs. If you are using prior versions of the SDK, we highly recommend planning your migration to the latest version as soon as possible.
 
 ## Get started with Voice on Android
 

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
             'targetSdk'          : 30,
             'material'           : '1.4.0',
             'firebase'           : '17.6.0',
-            'voiceAndroid'       : '6.0.0',
+            'voiceAndroid'       : '6.0.1',
             'audioSwitch'        : '1.1.2',
             'androidxLifecycle'  : '2.2.0',
             'junit'              : '1.1.1'
@@ -20,10 +20,6 @@ buildscript {
 
     repositories {
         jcenter()
-        maven {
-            url 'https://maven.google.com/'
-            name 'Google'
-        }
         google()
     }
     dependencies {
@@ -39,11 +35,6 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        jcenter()
-        maven {
-            url 'https://maven.google.com/'
-            name 'Google'
-        }
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,5 @@
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+android.useAndroidX=true
+android.enableJetifier=true


### PR DESCRIPTION
### 6.0.1

November 5, 2021

* Programmable Voice Android SDK 6.0.1[[Maven Central]](https://search.maven.org/artifact/com.twilio/voice-android/6.0.1/aar), [[docs]](https://twilio.github.io/twilio-voice-android/docs/6.0.1/) MD5 Checksum : 8be66d2ff2da31b89a5d904525a7b0a5

#### Maintenance

* Upgraded the SDK to use AndroidX.

#### Things to Note
- Restrictive networks may fail unless ICE servers are provided via `ConnectOptions.Builder.iceOptions(...)` or `AcceptOptions.Builder.iceOptions(...)`. ICE servers can be obtained from [Twilio Network Travarsal Service](https://www.twilio.com/stun-turn).

#### Library size report

| ABI             | APK Size Impact |
| --------------- | --------------- |
| x86             | 4MB             |
| x86_64          | 4MB             |
| armeabi-v7a     | 3.3MB           |
| arm64-v8a       | 3.8MB           |
| universal       | 14.8MB          |
**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
