### PR TITLE
VBLOCKS-342: Modified to request user for Bluetooth permissions on Android 12 devices

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,7 +10,8 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".VoiceActivity">
+        <activity android:name=".VoiceActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
@@ -19,7 +20,8 @@
 
         <service
             android:enabled="true"
-            android:name=".IncomingCallNotificationService">
+            android:name=".IncomingCallNotificationService"
+            android:exported="false">
             <intent-filter>
                 <action android:name="ACTION_ACCEPT" />
                 <action android:name="ACTION_REJECT" />
@@ -29,7 +31,8 @@
         <!-- [START fcm_listener] -->
         <service
             android:name=".fcm.VoiceFirebaseMessagingService"
-            android:stopWithTask="false">
+            android:stopWithTask="false"
+            android:exported="false">
             <intent-filter>
 
                 <action android:name="com.google.firebase.MESSAGING_EVENT" />

--- a/app/src/main/java/com/twilio/voice/quickstart/VoiceActivity.java
+++ b/app/src/main/java/com/twilio/voice/quickstart/VoiceActivity.java
@@ -617,14 +617,24 @@ public class VoiceActivity extends AppCompatActivity {
     @Override
     public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
         /*
-         * Check if microphone permissions is granted
+         * Check if required permissions are granted
          */
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            if (!hasPermissions(this, Manifest.permission.RECORD_AUDIO, Manifest.permission.BLUETOOTH_CONNECT)) {
+            if (!hasPermissions(this, Manifest.permission.RECORD_AUDIO)) {
                 Snackbar.make(coordinatorLayout,
-                        "Microphone &  BLUETOOTH_CONNECT permissions needed. Please allow in your application settings.",
+                        "Microphone permission needed. Please allow in your application settings.",
                         Snackbar.LENGTH_LONG).show();
             } else {
+                if (!hasPermissions(this, Manifest.permission.BLUETOOTH_CONNECT)) {
+                    Snackbar.make(coordinatorLayout,
+                            "Without bluetooth permission app will fail to use bluetooth.",
+                            Snackbar.LENGTH_LONG).show();
+                }
+                /*
+                 * Due to bluetooth permissions being requested at the same time as mic
+                 * permissions, AudioSwitch should be started after providing the user the option
+                 * to grant the necessary permissions for bluetooth.
+                 */
                 startAudioSwitch();
                 registerForCallInvites();
             }

--- a/app/src/main/java/com/twilio/voice/quickstart/VoiceActivity.java
+++ b/app/src/main/java/com/twilio/voice/quickstart/VoiceActivity.java
@@ -13,6 +13,7 @@ import android.content.pm.PackageManager;
 import android.content.res.ColorStateList;
 import android.media.AudioManager;
 import android.os.Build;
+import android.os.Build.VERSION_CODES;
 import android.os.Bundle;
 import android.os.SystemClock;
 import android.util.Log;
@@ -27,6 +28,7 @@ import android.widget.Chronometer;
 import android.widget.EditText;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.coordinatorlayout.widget.CoordinatorLayout;
 import androidx.core.app.ActivityCompat;
@@ -57,10 +59,13 @@ import java.util.Locale;
 
 import kotlin.Unit;
 
+import static android.content.pm.PackageManager.PERMISSION_GRANTED;
+
 public class VoiceActivity extends AppCompatActivity {
 
     private static final String TAG = "VoiceActivity";
     private static final int MIC_PERMISSION_REQUEST_CODE = 1;
+    private static final int PERMISSIONS_REQUEST_CODE = 100;
     private String accessToken = "PASTE_YOUR_ACCESS_TOKEN_HERE";
 
     /*
@@ -126,13 +131,6 @@ public class VoiceActivity extends AppCompatActivity {
         registerReceiver();
 
         /*
-         * Setup audio device management and set the volume control stream
-         */
-        audioSwitch = new AudioSwitch(getApplicationContext());
-        savedVolumeControlStream = getVolumeControlStream();
-        setVolumeControlStream(AudioManager.STREAM_VOICE_CALL);
-
-        /*
          * Setup the UI
          */
         resetUI();
@@ -145,11 +143,26 @@ public class VoiceActivity extends AppCompatActivity {
         /*
          * Ensure the microphone permission is enabled
          */
-        if (!checkPermissionForMicrophone()) {
-            requestPermissionForMicrophone();
+        if (Build.VERSION.SDK_INT > VERSION_CODES.R) {
+            if (!checkPermissionForMicrophoneAndBluetooth()) {
+                requestPermissionForMicrophoneAndBluetooth();
+            } else {
+                registerForCallInvites();
+            }
         } else {
-            registerForCallInvites();
+            if (!checkPermissionForMicrophone()) {
+                requestPermissionForMicrophone();
+            } else {
+                registerForCallInvites();
+            }
         }
+
+        /*
+         * Setup audio device management and set the volume control stream
+         */
+        audioSwitch = new AudioSwitch(getApplicationContext());
+        savedVolumeControlStream = getVolumeControlStream();
+        setVolumeControlStream(AudioManager.STREAM_VOICE_CALL);
     }
 
     @Override
@@ -376,7 +389,7 @@ public class VoiceActivity extends AppCompatActivity {
     }
 
     private void handleIncomingCall() {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+        if (Build.VERSION.SDK_INT < VERSION_CODES.O) {
             showIncomingCallDialog();
         } else {
             if (isAppVisible()) {
@@ -569,6 +582,22 @@ public class VoiceActivity extends AppCompatActivity {
         return resultMic == PackageManager.PERMISSION_GRANTED;
     }
 
+    private boolean checkPermissionForMicrophoneAndBluetooth() {
+        if (hasPermissions(this, Manifest.permission.RECORD_AUDIO,
+                Manifest.permission.BLUETOOTH_CONNECT)) {
+            /*
+             * Start the audio device selector after the menu is created and update the icon when the
+             * selected audio device changes.
+             */
+            audioSwitch.start((audioDevices, audioDevice) -> {
+                updateAudioDeviceIcon(audioDevice);
+                return Unit.INSTANCE;
+            });
+        }
+        return (hasPermissions(this, Manifest.permission.RECORD_AUDIO,
+                Manifest.permission.BLUETOOTH_CONNECT));
+    }
+
     private void requestPermissionForMicrophone() {
         if (ActivityCompat.shouldShowRequestPermissionRationale(this, Manifest.permission.RECORD_AUDIO)) {
             Snackbar.make(coordinatorLayout,
@@ -582,13 +611,45 @@ public class VoiceActivity extends AppCompatActivity {
         }
     }
 
+    @RequiresApi(api = VERSION_CODES.M)
+    private void requestPermissionForMicrophoneAndBluetooth() {
+        if (!hasPermissions(this, Manifest.permission.RECORD_AUDIO,
+                Manifest.permission.BLUETOOTH_CONNECT)) {
+            requestPermissions(
+                    new String[]{Manifest.permission.RECORD_AUDIO,
+                            Manifest.permission.BLUETOOTH_CONNECT},
+                    PERMISSIONS_REQUEST_CODE);
+        } else {
+            registerForCallInvites();
+        }
+    }
+
+    public static boolean hasPermissions(Context context, String... permissions) {
+        if (context != null && permissions != null) {
+            for (String permission : permissions) {
+                if (ActivityCompat.checkSelfPermission(context, permission) != PERMISSION_GRANTED) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
     @Override
     public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
         /*
          * Check if microphone permissions is granted
          */
-        if (requestCode == MIC_PERMISSION_REQUEST_CODE && permissions.length > 0) {
-            if (grantResults[0] != PackageManager.PERMISSION_GRANTED) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            if (checkPermissionForMicrophoneAndBluetooth()) {
+                registerForCallInvites();
+            } else {
+                Snackbar.make(coordinatorLayout,
+                        "Microphone &  BLUETOOTH_CONNECT permissions needed. Please allow in your application settings.",
+                        Snackbar.LENGTH_LONG).show();
+            }
+        } else {
+            if (hasPermissions(this, Manifest.permission.RECORD_AUDIO)) {
                 Snackbar.make(coordinatorLayout,
                         "Microphone permissions needed. Please allow in your application settings.",
                         Snackbar.LENGTH_LONG).show();
@@ -607,11 +668,13 @@ public class VoiceActivity extends AppCompatActivity {
         /*
          * Start the audio device selector after the menu is created and update the icon when the
          * selected audio device changes.
-         */
+
         audioSwitch.start((audioDevices, audioDevice) -> {
             updateAudioDeviceIcon(audioDevice);
             return Unit.INSTANCE;
         });
+
+         */
 
         return true;
     }

--- a/app/src/main/java/com/twilio/voice/quickstart/VoiceActivity.java
+++ b/app/src/main/java/com/twilio/voice/quickstart/VoiceActivity.java
@@ -665,17 +665,6 @@ public class VoiceActivity extends AppCompatActivity {
         inflater.inflate(R.menu.menu, menu);
         audioDeviceMenuItem = menu.findItem(R.id.menu_audio_device);
 
-        /*
-         * Start the audio device selector after the menu is created and update the icon when the
-         * selected audio device changes.
-
-        audioSwitch.start((audioDevices, audioDevice) -> {
-            updateAudioDeviceIcon(audioDevice);
-            return Unit.INSTANCE;
-        });
-
-         */
-
         return true;
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,14 +6,14 @@ buildscript {
             'java'               : JavaVersion.VERSION_1_8,
             'androidGradlePlugin': '4.1.1',
             'googleServices'     : '4.3.10',
-            'compileSdk'         : 30,
+            'compileSdk'         : 31,
             'buildTools'         : '30.0.2',
             'minSdk'             : 21,
-            'targetSdk'          : 30,
+            'targetSdk'          : 31,
             'material'           : '1.4.0',
             'firebase'           : '17.6.0',
             'voiceAndroid'       : '6.0.1',
-            'audioSwitch'        : '1.1.2',
+            'audioSwitch'        : '1.1.3',
             'androidxLifecycle'  : '2.2.0',
             'junit'              : '1.1.1'
     ]


### PR DESCRIPTION
## Description

Updated to request user for Bluetooth permissions on Android 12 and delayed the start of audioswitch. Used the latest version of AudioSwitch library.

## Validation

Reproduced the android 12 crash with no  Bluetooth permission.

* Ran application on an Android 12 device. After permissions were accepted, the Bluetooth worked.
* Ran application on an Android 12 device. When permissions were denied, the app did not crash.
* Ran application on older devices, app works as expected. 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
