### PR TITLE
Consume Voice Android SDK 6.0.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,9 +25,9 @@ aliases:
   - &build-defaults
     working_directory: *workspace
     docker:
-      - image: circleci/android:api-28-node@sha256:a8d15723766a8f32f1a4ead42c5441bb0ded2e832329291cb4bbd9f1d1557721
+      - image: cimg/android:2021.10.2-node
     environment:
-      - _JAVA_OPTIONS: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
+      - _JAVA_OPTIONS: "-XX:+UnlockExperimentalVMOptions -Xmx3g"
 
 jobs:
   setup-workspace:

--- a/build.gradle
+++ b/build.gradle
@@ -3,8 +3,8 @@
 buildscript {
 
     ext.versions = [
-            'java'               : JavaVersion.VERSION_1_8,
-            'androidGradlePlugin': '4.2.2',
+            'java'               : JavaVersion.VERSION_11,
+            'androidGradlePlugin': '7.0.4',
             'googleServices'     : '4.3.10',
             'compileSdk'         : 31,
             'buildTools'         : '30.0.2',
@@ -12,7 +12,7 @@ buildscript {
             'targetSdk'          : 31,
             'material'           : '1.4.0',
             'firebase'           : '17.6.0',
-            'voiceAndroid'       : '6.0.2',
+            'voiceAndroid'       : '6.0.7',
             'audioSwitch'        : '1.1.4',
             'androidxLifecycle'  : '2.2.0',
             'junit'              : '1.1.1'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip


### PR DESCRIPTION
### 6.0.7

February 8th, 2022

* Programmable Voice Android SDK 6.0.7[[Maven Central]](https://search.maven.org/artifact/com.twilio/voice-android/6.0.7/aar), [[docs]](https://twilio.github.io/twilio-voice-android/docs/6.0.7/) MD5 Checksum : ddb5b1530276c8a5ceb2fc773a5e6dc7


#### New Features

- Upgraded SDK to build with Java 11.
- Updated the SDK to Android Gradle Plugin 7.0.4.
- SDK now uses max timeout value 10 minutes by default to answer an incoming call.

#### Things to Note
- Restrictive networks may fail unless ICE servers are provided via `ConnectOptions.Builder.iceOptions(...)` or `AcceptOptions.Builder.iceOptions(...)`. ICE servers can be obtained from [Twilio Network Travarsal Service](https://www.twilio.com/stun-turn).


#### Library size report

| ABI             | APK Size Impact |
| --------------- | --------------- |
| x86             | 4MB             |
| x86_64          | 4MB             |
| armeabi-v7a     | 3.3MB           |
| arm64-v8a       | 3.8MB           |
| universal       | 14.9MB          |


**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
