### PR TITLE
Instructions to manage push credentials using the Notify Credential Resource API

### DIFF
--- a/Docs/push-credentials-via-notify-api.md
+++ b/Docs/push-credentials-via-notify-api.md
@@ -3,7 +3,7 @@
 Voice SDK users can manage their Push Credentials in the developer console (**Console > Account > Keys & Credentials > Credentials**). Currently the Push Credential management page only supports the default region (US1). To create or update Push Credentials for other regional (i.e. Australia) usage, developers can use the Notify public API to manage their Push Credentials. Follow the instructions of the [Credential Resource API](https://www.twilio.com/docs/notify/api/credential-resource) and replace the endpoint with the regional endpoint, for example https://notify.sydney.au1.twilio.com for the Australia region.
 
 You will also need:
-- FCM key: follow the [instructions]((https://github.com/twilio/voice-quickstart-android#1-generate-google-servicesjson)) to get the API key.
+- FCM key: follow the [instructions]((https://github.com/twilio/voice-quickstart-android#1-generate-google-servicesjson)) to get the FCM key.
 - Twilio account credentials: find your API auth token for the specific region in the developer console. Go to **Console > Account > Keys & Credentials > API keys & tokens** and select the region in the dropdown menu.
 
 Example of creating an `AU1` Push Credential for FCM:

--- a/Docs/push-credentials-via-notify-api.md
+++ b/Docs/push-credentials-via-notify-api.md
@@ -1,0 +1,25 @@
+## Create Push Credentials via the Notify Credential Resource API
+
+Voice SDK users can manage their Push Credentials in the developer console (**Console > Account > Keys & Credentials > Credentials**). Currently the Push Credential management page only supports the default region (US1). To create or update Push Credentials for other regional (i.e. Australia) usage, developers can use the Notify public API to manage their Push Credentials. Follow the instructions of the [Credential Resource API](https://www.twilio.com/docs/notify/api/credential-resource) and replace the endpoint with the regional endpoint, for example https://notify.sydney.au1.twilio.com for the Australia region.
+
+You will also need:
+- FCM key: follow the [instructions]((https://github.com/twilio/voice-quickstart-android#1-generate-google-servicesjson)) to get the API key.
+- Twilio account credentials: find your API auth token for the specific region in the developer console. Go to **Console > Account > Keys & Credentials > API keys & tokens** and select the region in the dropdown menu.
+
+Example of creating an `AU1` Push Credential for FCM:
+
+```
+curl -X POST https://notify.sydney.au1.twilio.com/v1/Credentials \
+--data-urlencode "Type=fcm" \
+--data-urlencode "Secret=$FCM_SERVER_KEY" \
+-u $TWILIO_ACCOUNT_SID:$TWILIO_AUTH_TOKEN
+```
+
+To update a Push Credential (CR****) in `AU1`:
+
+```
+curl -X POST https://notify.sydney.au1.twilio.com/v1/Credentials/CR**** \
+--data-urlencode "Type=fcm" \
+--data-urlencode "Secret=$FCM_SERVER_KEY" \
+-u $TWILIO_ACCOUNT_SID:$TWILIO_AUTH_TOKEN
+```

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 ## References
 - [Access Tokens](https://github.com/twilio/voice-quickstart-android/blob/master/Docs/access-token.md) - Using access tokens
 - [Managing Push Credentials](https://github.com/twilio/voice-quickstart-android/blob/master/Docs/manage-push-credentials.md) - Managing Push Credentials
+- [Managing Regional Push Credentials using Notify Credential Resource API](https://github.com/twilio/voice-quickstart-android/blob/master/Docs/push-credentials-via-notify-api.md) - Create or update push credentials for regional usage
 - [Troubleshooting](https://github.com/twilio/voice-quickstart-android/blob/master/Docs/troubleshooting.md) - Troubleshooting
 - [More Documentation](#more-documentation) - More documentation related to the Voice Android SDK
 - [Emulator Support](#emulator-support) - Android emulator support


### PR DESCRIPTION
- [x] I acknowledge that all my contributions will be made under the project's license.

- Instruction and sample code showing how to manage Push Credentials (for regional) using the Notify Credential Resource API
- Reference link in the README

Note that this page will be referenced in the changelog when the regional feature is released.