### PR TITLE
Using Voice Android 6.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
             'targetSdk'          : 31,
             'material'           : '1.4.0',
             'firebase'           : '17.6.0',
-            'voiceAndroid'       : '6.0.7',
+            'voiceAndroid'       : '6.1.0',
             'audioSwitch'        : '1.1.4',
             'androidxLifecycle'  : '2.2.0',
             'junit'              : '1.1.1'


### PR DESCRIPTION
### 6.1.0

May 9th, 2022

* Programmable Voice Android SDK 6.1.0[[Maven Central]](https://search.maven.org/artifact/com.twilio/voice-android/6.1.0/aar), [[docs]](https://twilio.github.io/twilio-voice-android/docs/6.1.0/) MD5 Checksum : 164b77f552b7a2a9c8c40ace9b30077f


### API updates

- The Voice Android SDK now supports Twilio Regional by providing the home region specifier in the access token header when calling the `Voice.register()` method, the `Voice.unregister()` method, or the `Voice.connect()` method.

Existing customers can now migrate their Voice use-cases to data centers in Ireland or Australia to establish data residency within the region. In addition, new customers may now select Ireland or Australia as their region of choice for Voice related use cases. There is no additional cost to use the new data centers in Ireland or Australia. To learn more about Regional Voice, check out our [blog post](https://www.twilio.com/blog/expanded-data-protection-options-eu-schrems-ii#ongoing-updates-q4) or head over to our [developer docs](https://www.twilio.com/docs/global-infrastructure) to get started.

Below is an example of specifying home region in the access token using the Twilio [Node.js](https://www.twilio.com/docs/libraries/node) helper library:

```.node
const accessToken = new twilio.jwt.AccessToken(
    credentials.accountSid,
    credentials.apiKeySid,
    credentials.apiKeySecret, {
      identity,
      ttl,
      region: 'au1',
    },
  );
```

The decoded header of your access token should look like this:

```
{
  "alg": "HS256",
  "typ": "JWT",
  "cty": "twilio-fpa;v=1",
  "twr": "au1"
}
```
#### Maintenance

- The SDK compileSDKVersion and targetSDKVersion were updated to 31.
- Updated `getStats(...)` API doc.

#### Bug Fixes

- Fixed `IceCandidatePairStats` javadoc. Added `responsesSent` attribute to `IceCandidatePairStats`.

#### Things to Note
- Restrictive networks may fail unless ICE servers are provided via `ConnectOptions.Builder.iceOptions(...)` or `AcceptOptions.Builder.iceOptions(...)`. ICE servers can be obtained from [Twilio Network Travarsal Service](https://www.twilio.com/stun-turn).

#### Library size report

| ABI             | APK Size Impact |
| --------------- | --------------- |
| x86             | 4MB             |
| x86_64          | 4MB             |
| armeabi-v7a     | 3.3MB           |
| arm64-v8a       | 3.8MB           |
| universal       | 14.9MB          |

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
