### PR TITLE
Use Voice Android SDK 6.1.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
             'targetSdk'          : 31,
             'material'           : '1.4.0',
             'firebase'           : '17.6.0',
-            'voiceAndroid'       : '6.1.0',
+            'voiceAndroid'       : '6.1.1',
             'audioSwitch'        : '1.1.4',
             'androidxLifecycle'  : '2.2.0',
             'junit'              : '1.1.1'


### PR DESCRIPTION
### 6.1.1

May 26th, 2022

* Programmable Voice Android SDK 6.1.1[[Maven Central]](https://search.maven.org/artifact/com.twilio/voice-android/6.1.1/aar), [[docs]](https://twilio.github.io/twilio-voice-android/docs/6.1.1/) MD5 Checksum : 355865e5f9e1f82be63af8225c4f0bfc

#### Bug Fixes
- Fixed a crash when the home region specifier (`twr`) in the access token is `null`.

#### Things to Note
- Restrictive networks may fail unless ICE servers are provided via `ConnectOptions.Builder.iceOptions(...)` or `AcceptOptions.Builder.iceOptions(...)`. ICE servers can be obtained from [Twilio Network Traversal Service](https://www.twilio.com/stun-turn).

Size Report

| ABI             | APK Size Impact |
| --------------- | --------------- |
| x86             | 4MB             |
| x86_64          | 4MB             |
| armeabi-v7a     | 3.3MB           |
| arm64-v8a       | 3.8MB           |
| universal       | 14.9MB          |

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
