### PR TITLE
VBLOCKS-1606: fix for foregrounding on Android 31

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -73,7 +73,7 @@ dependencies {
     implementation "com.google.android.material:material:${versions.material}"
     implementation "com.google.firebase:firebase-messaging:${versions.firebase}"
     implementation "androidx.lifecycle:lifecycle-extensions:${versions.androidxLifecycle}"
-    implementation 'com.google.firebase:firebase-auth:21.0.5'
+    implementation 'com.google.firebase:firebase-auth:21.3.0'
     androidTestImplementation "androidx.test.ext:junit:${versions.junit}"
 
     // Import the BoM

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,7 +17,15 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-
+        <activity
+            android:name=".NotificationProxyActivity"
+            android:parentActivityName=".VoiceActivity"
+            android:noHistory="true"
+            android:excludeFromRecents="true"
+            android:taskAffinity=""
+            android:launchMode="singleTask"
+            android:theme="@android:style/Theme.Translucent.NoTitleBar"
+            android:exported="true" />
         <service
             android:enabled="true"
             android:name=".IncomingCallNotificationService"
@@ -34,7 +42,7 @@
             android:stopWithTask="false"
             android:exported="false">
             <intent-filter>
-
+                <action android:name="com.google.firebase.INSTANCE_ID_EVENT" />
                 <action android:name="com.google.firebase.MESSAGING_EVENT" />
             </intent-filter>
         </service>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -42,7 +42,6 @@
             android:stopWithTask="false"
             android:exported="false">
             <intent-filter>
-                <action android:name="com.google.firebase.INSTANCE_ID_EVENT" />
                 <action android:name="com.google.firebase.MESSAGING_EVENT" />
             </intent-filter>
         </service>

--- a/app/src/main/java/com/twilio/voice/quickstart/IncomingCallNotificationService.java
+++ b/app/src/main/java/com/twilio/voice/quickstart/IncomingCallNotificationService.java
@@ -58,7 +58,7 @@ public class IncomingCallNotificationService extends Service {
     }
 
     private Notification createNotification(CallInvite callInvite, int notificationId, int channelImportance) {
-        Intent intent = new Intent(this, VoiceActivity.class);
+        Intent intent = new Intent(this, NotificationProxyActivity.class);
         intent.setAction(Constants.ACTION_INCOMING_CALL_NOTIFICATION);
         intent.putExtra(Constants.INCOMING_CALL_NOTIFICATION_ID, notificationId);
         intent.putExtra(Constants.INCOMING_CALL_INVITE, callInvite);
@@ -108,13 +108,13 @@ public class IncomingCallNotificationService extends Service {
                                           final CallInvite callInvite,
                                           int notificationId,
                                           String channelId) {
-        Intent rejectIntent = new Intent(getApplicationContext(), IncomingCallNotificationService.class);
+        Intent rejectIntent = new Intent(getApplicationContext(), NotificationProxyActivity.class);
         rejectIntent.setAction(Constants.ACTION_REJECT);
         rejectIntent.putExtra(Constants.INCOMING_CALL_INVITE, callInvite);
         rejectIntent.putExtra(Constants.INCOMING_CALL_NOTIFICATION_ID, notificationId);
         PendingIntent piRejectIntent = PendingIntent.getService(getApplicationContext(), notificationId, rejectIntent, PendingIntent.FLAG_IMMUTABLE);
 
-        Intent acceptIntent = new Intent(getApplicationContext(), VoiceActivity.class);
+        Intent acceptIntent = new Intent(getApplicationContext(), NotificationProxyActivity.class);
         acceptIntent.setAction(Constants.ACTION_ACCEPT);
         acceptIntent.putExtra(Constants.INCOMING_CALL_INVITE, callInvite);
         acceptIntent.putExtra(Constants.INCOMING_CALL_NOTIFICATION_ID, notificationId);
@@ -157,13 +157,6 @@ public class IncomingCallNotificationService extends Service {
 
     private void accept(CallInvite callInvite, int notificationId) {
         endForeground();
-        Intent activeCallIntent = new Intent(this, VoiceActivity.class);
-        activeCallIntent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
-        activeCallIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-        activeCallIntent.putExtra(Constants.INCOMING_CALL_INVITE, callInvite);
-        activeCallIntent.putExtra(Constants.INCOMING_CALL_NOTIFICATION_ID, notificationId);
-        activeCallIntent.setAction(Constants.ACTION_ACCEPT);
-        startActivity(activeCallIntent);
     }
 
     private void reject(CallInvite callInvite) {
@@ -180,7 +173,6 @@ public class IncomingCallNotificationService extends Service {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             setCallInProgressNotification(callInvite, notificationId);
         }
-        sendCallInviteToActivity(callInvite, notificationId);
     }
 
     private void endForeground() {
@@ -198,21 +190,6 @@ public class IncomingCallNotificationService extends Service {
         }
     }
 
-    /*
-     * Send the CallInvite to the VoiceActivity. Start the activity if it is not running already.
-     */
-    private void sendCallInviteToActivity(CallInvite callInvite, int notificationId) {
-        if (Build.VERSION.SDK_INT >= 29 && !isAppVisible()) {
-            return;
-        }
-        Intent intent = new Intent(this, VoiceActivity.class);
-        intent.setAction(Constants.ACTION_INCOMING_CALL);
-        intent.putExtra(Constants.INCOMING_CALL_NOTIFICATION_ID, notificationId);
-        intent.putExtra(Constants.INCOMING_CALL_INVITE, callInvite);
-        intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
-        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-        this.startActivity(intent);
-    }
 
     private boolean isAppVisible() {
         return ProcessLifecycleOwner

--- a/app/src/main/java/com/twilio/voice/quickstart/NotificationProxyActivity.java
+++ b/app/src/main/java/com/twilio/voice/quickstart/NotificationProxyActivity.java
@@ -1,0 +1,53 @@
+package com.twilio.voice.quickstart;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Bundle;
+
+public class NotificationProxyActivity extends Activity {
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    handleIntent(getIntent());
+    finish();
+  }
+
+  @Override
+  protected void onNewIntent(Intent intent) {
+    super.onNewIntent(intent);
+    handleIntent(intent);
+    finish();
+  }
+
+  private void handleIntent(Intent intent) {
+    String action = intent.getAction();
+    if (action != null) {
+      switch (action) {
+        case Constants.ACTION_INCOMING_CALL:
+        case Constants.ACTION_ACCEPT:
+          launchService(intent);
+          launchMainActivity(intent);
+          break;
+        default:
+          launchService(intent);
+          break;
+      }
+    }
+  }
+
+  private void launchMainActivity(Intent intent) {
+    try{
+      Intent launchIntent = new Intent(intent);
+      launchIntent.setClass(this, VoiceActivity.class);
+      launchIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
+      startActivity(launchIntent);
+    }catch (Exception e){
+      e.printStackTrace();
+    }
+  }
+  private void launchService(Intent intent) {
+    Intent launchIntent = new Intent(intent);
+    launchIntent.setClass(this, IncomingCallNotificationService.class);
+    startService(launchIntent);
+  }
+}

--- a/app/src/main/java/com/twilio/voice/quickstart/VoiceActivity.java
+++ b/app/src/main/java/com/twilio/voice/quickstart/VoiceActivity.java
@@ -66,7 +66,7 @@ public class VoiceActivity extends AppCompatActivity {
     private static final String TAG = "VoiceActivity";
     private static final int MIC_PERMISSION_REQUEST_CODE = 1;
     private static final int PERMISSIONS_REQUEST_CODE = 100;
-    private String accessToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImN0eSI6InR3aWxpby1mcGE7dj0xIn0.eyJqdGkiOiJTSzhiNTk4YTUyNGNiOThlNzdiMTdiMmZmN2Y5NmJmNWE5LTE2ODAyOTcxMDUiLCJncmFudHMiOnsiaWRlbnRpdHkiOiJhbGljZSIsInZvaWNlIjp7ImluY29taW5nIjp7ImFsbG93Ijp0cnVlfSwib3V0Z29pbmciOnsiYXBwbGljYXRpb25fc2lkIjoiQVBiNDY5YzU2NDJjMjBmNmM2NjVmNjcyNzMzNDdiOTY5MiJ9LCJwdXNoX2NyZWRlbnRpYWxfc2lkIjoiQ1I4NjA0YjlkZmFjZmYwMWU5MTc5YWM5NzUwNTdmYjkxMSJ9fSwiaWF0IjoxNjgwMjk3MTA1LCJleHAiOjE2ODAzMDA3MDUsImlzcyI6IlNLOGI1OThhNTI0Y2I5OGU3N2IxN2IyZmY3Zjk2YmY1YTkiLCJzdWIiOiJBQzE0OGI2ZjkwNjgwMWZmZTYzMmEzMDEyYjlhMjg3ZWU4In0.u7Qe3G1U5cv2rxyx0iaYlNVel3vNV_yCTMg6E1VZPKQ";
+    private String accessToken = "PASTE_YOUR_ACCESS_TOKEN_HERE";
 
     /*
      * Audio device management

--- a/app/src/main/java/com/twilio/voice/quickstart/VoiceActivity.java
+++ b/app/src/main/java/com/twilio/voice/quickstart/VoiceActivity.java
@@ -66,7 +66,7 @@ public class VoiceActivity extends AppCompatActivity {
     private static final String TAG = "VoiceActivity";
     private static final int MIC_PERMISSION_REQUEST_CODE = 1;
     private static final int PERMISSIONS_REQUEST_CODE = 100;
-    private String accessToken = "PASTE_YOUR_ACCESS_TOKEN_HERE";
+    private String accessToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImN0eSI6InR3aWxpby1mcGE7dj0xIn0.eyJqdGkiOiJTSzhiNTk4YTUyNGNiOThlNzdiMTdiMmZmN2Y5NmJmNWE5LTE2ODAyOTcxMDUiLCJncmFudHMiOnsiaWRlbnRpdHkiOiJhbGljZSIsInZvaWNlIjp7ImluY29taW5nIjp7ImFsbG93Ijp0cnVlfSwib3V0Z29pbmciOnsiYXBwbGljYXRpb25fc2lkIjoiQVBiNDY5YzU2NDJjMjBmNmM2NjVmNjcyNzMzNDdiOTY5MiJ9LCJwdXNoX2NyZWRlbnRpYWxfc2lkIjoiQ1I4NjA0YjlkZmFjZmYwMWU5MTc5YWM5NzUwNTdmYjkxMSJ9fSwiaWF0IjoxNjgwMjk3MTA1LCJleHAiOjE2ODAzMDA3MDUsImlzcyI6IlNLOGI1OThhNTI0Y2I5OGU3N2IxN2IyZmY3Zjk2YmY1YTkiLCJzdWIiOiJBQzE0OGI2ZjkwNjgwMWZmZTYzMmEzMDEyYjlhMjg3ZWU4In0.u7Qe3G1U5cv2rxyx0iaYlNVel3vNV_yCTMg6E1VZPKQ";
 
     /*
      * Audio device management

--- a/build.gradle
+++ b/build.gradle
@@ -13,13 +13,13 @@ buildscript {
             'material'           : '1.4.0',
             'firebase'           : '17.6.0',
             'voiceAndroid'       : '6.1.2',
-            'audioSwitch'        : '1.1.4',
+            'audioSwitch'        : '1.1.7',
             'androidxLifecycle'  : '2.2.0',
             'junit'              : '1.1.1'
     ]
 
     repositories {
-        jcenter()
+        mavenCentral()
         google()
     }
     dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -11,11 +11,11 @@ buildscript {
             'minSdk'             : 21,
             'targetSdk'          : 31,
             'material'           : '1.4.0',
-            'firebase'           : '17.6.0',
-            'voiceAndroid'       : '6.1.2',
+            'firebase'           : '23.1.2',
+            'voiceAndroid'       : '6.1.3',
             'audioSwitch'        : '1.1.7',
             'androidxLifecycle'  : '2.2.0',
-            'junit'              : '1.1.1'
+            'junit'              : '1.1.5'
     ]
 
     repositories {


### PR DESCRIPTION
Due to changes in Android 31, services can no longer launch activities. Much like the react-native sdk, now there is a proxy invisible activity that either proxies events to the call handling service or to the UI activity.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
