### PR TITLE
VBLOCKS-2628: Now requests for Notification permissions and cleaned up permissions requests

### DIFF
--- a/app/src/connection_service/java/com/twilio/voice/quickstart/VoiceActivity.java
+++ b/app/src/connection_service/java/com/twilio/voice/quickstart/VoiceActivity.java
@@ -74,7 +74,7 @@ public class VoiceActivity extends AppCompatActivity {
     public static final String ACTION_DTMF_SEND = "ACTION_DTMF_SEND";
     public static final String DTMF = "DTMF";
     private static final int PERMISSIONS_ALL = 100;
-    private final String accessToken = "PASTE_YOUR_ACCESS_TOKEN_HERE";
+    private final String accessToken = "PASTfE_YOUR_ACCESS_TOKEN_HERE";
 
 
     /*
@@ -150,6 +150,14 @@ public class VoiceActivity extends AppCompatActivity {
         handleIncomingCallIntent(getIntent());
 
         /*
+         * Setup audio device management and set the volume control stream
+         */
+        audioSwitch = new AudioSwitch(getApplicationContext());
+        audioSwitch.setLoggingEnabled(true);
+        savedVolumeControlStream = getVolumeControlStream();
+        setVolumeControlStream(AudioManager.STREAM_VOICE_CALL);
+
+        /*
          * Ensure required permissions are enabled
          */
         String[] permissionsList = providePermissions();
@@ -159,14 +167,6 @@ public class VoiceActivity extends AppCompatActivity {
             startAudioSwitch();
             registerForCallInvites();
         }
-
-        /*
-         * Setup audio device management and set the volume control stream
-         */
-        audioSwitch = new AudioSwitch(getApplicationContext());
-        audioSwitch.setLoggingEnabled(true);
-        savedVolumeControlStream = getVolumeControlStream();
-        setVolumeControlStream(AudioManager.STREAM_VOICE_CALL);
     }
 
     @Override
@@ -380,7 +380,6 @@ public class VoiceActivity extends AppCompatActivity {
     protected void onResume() {
         super.onResume();
         registerReceiver();
-        startAudioSwitch();
     }
 
     @Override
@@ -666,7 +665,7 @@ public class VoiceActivity extends AppCompatActivity {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults);
         final Map<String, String> permissionsMessageMap = providePermissionsMesageMap();
         for (String permission : permissions) {
-            if (hasPermissions(this, permission)) {
+            if (!hasPermissions(this, permission)) {
                 Snackbar.make(
                         coordinatorLayout,
                         Objects.requireNonNull(permissionsMessageMap.get(permission)),

--- a/app/src/connection_service/java/com/twilio/voice/quickstart/VoiceActivity.java
+++ b/app/src/connection_service/java/com/twilio/voice/quickstart/VoiceActivity.java
@@ -74,7 +74,7 @@ public class VoiceActivity extends AppCompatActivity {
     public static final String ACTION_DTMF_SEND = "ACTION_DTMF_SEND";
     public static final String DTMF = "DTMF";
     private static final int PERMISSIONS_ALL = 100;
-    private final String accessToken = "PASTfE_YOUR_ACCESS_TOKEN_HERE";
+    private final String accessToken = "PASTE_YOUR_ACCESS_TOKEN_HERE";
 
 
     /*

--- a/app/src/connection_service/res/values/strings.xml
+++ b/app/src/connection_service/res/values/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="call_permissions_rational">Call phone permission needed. Please allow in your application settings.</string>
+    <string name="manage_call_permissions_rational">Manage Own Calls permission needed. Please allow in your application settings.</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,4 +7,7 @@
     <string name="connection_service_name">Twilio Voice</string>
     <string name="callHint">Dial a client name or phone number. Leaving the field empty results in an automated response.</string>
     <string name="select_device">Select Audio Device</string>
+    <string name="audio_permissions_rational">Audio recording permission needed. Please allow in your application settings.</string>
+    <string name="bluetooth_permissions_rational">Without bluetooth permission app will fail to use bluetooth.</string>
+    <string name="notification_permissions_rational">Notification permissions needed for receiving incoming phone calls. Please allow in your application settings.</string>
 </resources>

--- a/app/src/standard/java/com/twilio/voice/quickstart/VoiceActivity.java
+++ b/app/src/standard/java/com/twilio/voice/quickstart/VoiceActivity.java
@@ -141,22 +141,22 @@ public class VoiceActivity extends AppCompatActivity {
         handleIncomingCallIntent(getIntent());
 
         /*
+         * Setup audio device management and set the volume control stream
+         */
+        audioSwitch = new AudioSwitch(getApplicationContext());
+        savedVolumeControlStream = getVolumeControlStream();
+        setVolumeControlStream(AudioManager.STREAM_VOICE_CALL);
+
+        /*
          * Ensure required permissions are enabled
          */
         String[] permissionsList = providePermissions();
         if (!hasPermissions(this, permissionsList)) {
             ActivityCompat.requestPermissions(this, permissionsList, PERMISSIONS_ALL);
         } else {
-            startAudioSwitch();
             registerForCallInvites();
+            startAudioSwitch();
         }
-
-        /*
-         * Setup audio device management and set the volume control stream
-         */
-        audioSwitch = new AudioSwitch(getApplicationContext());
-        savedVolumeControlStream = getVolumeControlStream();
-        setVolumeControlStream(AudioManager.STREAM_VOICE_CALL);
     }
 
     @Override
@@ -361,7 +361,6 @@ public class VoiceActivity extends AppCompatActivity {
     protected void onResume() {
         super.onResume();
         registerReceiver();
-        startAudioSwitch();
     }
 
     @Override
@@ -623,7 +622,7 @@ public class VoiceActivity extends AppCompatActivity {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults);
         final Map<String, String> permissionsMessageMap = providePermissionsMesageMap();
         for (String permission : permissions) {
-            if (hasPermissions(this, permission)) {
+            if (!hasPermissions(this, permission)) {
                 Snackbar.make(
                         coordinatorLayout,
                         Objects.requireNonNull(permissionsMessageMap.get(permission)),


### PR DESCRIPTION
Now QuickStart requests POST_NOTIFICATION permissions (android 33+) and cleaned up notification request code. Also fixed an issue where audio switch was being constructed every time the application was brought into the foreground.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
