### PR TITLE
Update voice android sdk to 6.5.0 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
             'targetSdk'          : 33,
             'material'           : '1.9.0',
             'firebase'           : '23.2.1',
-            'voiceAndroid'       : '6.4.1',
+            'voiceAndroid'       : '6.5.0',
             'audioSwitch'        : '1.1.8',
             'androidxLifecycle'  : '2.2.0',
             'junit'              : '1.1.5'


### PR DESCRIPTION
This PR updates the Quickstart to the latest Voice Android SDK - 6.5.0
Here is the published changelog for this release: https://www.twilio.com/docs/voice/sdks/android/3x-changelog#650

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
