### PR TITLE
[VBLOCKS-3457]:fix gh issue, decline call notification doesn't work

### DIFF
--- a/app/src/connection_service/java/com/twilio/voice/quickstart/IncomingCallNotificationService.java
+++ b/app/src/connection_service/java/com/twilio/voice/quickstart/IncomingCallNotificationService.java
@@ -129,7 +129,7 @@ public class IncomingCallNotificationService extends Service {
         rejectIntent.setAction(Constants.ACTION_REJECT);
         rejectIntent.putExtra(Constants.INCOMING_CALL_INVITE, callInvite);
         rejectIntent.putExtra(Constants.INCOMING_CALL_NOTIFICATION_ID, notificationId);
-        PendingIntent piRejectIntent = PendingIntent.getService(getApplicationContext(), notificationId, rejectIntent, PendingIntent.FLAG_IMMUTABLE);
+        PendingIntent piRejectIntent = PendingIntent.getActivity(getApplicationContext(), notificationId, rejectIntent, PendingIntent.FLAG_IMMUTABLE);
 
         Intent acceptIntent = new Intent(getApplicationContext(), NotificationProxyActivity.class);
         acceptIntent.setAction(Constants.ACTION_ACCEPT);

--- a/app/src/standard/java/com/twilio/voice/quickstart/IncomingCallNotificationService.java
+++ b/app/src/standard/java/com/twilio/voice/quickstart/IncomingCallNotificationService.java
@@ -114,7 +114,7 @@ public class IncomingCallNotificationService extends Service {
         rejectIntent.setAction(Constants.ACTION_REJECT);
         rejectIntent.putExtra(Constants.INCOMING_CALL_INVITE, callInvite);
         rejectIntent.putExtra(Constants.INCOMING_CALL_NOTIFICATION_ID, notificationId);
-        PendingIntent piRejectIntent = PendingIntent.getService(getApplicationContext(), notificationId, rejectIntent, PendingIntent.FLAG_IMMUTABLE);
+        PendingIntent piRejectIntent = PendingIntent.getActivity(getApplicationContext(), notificationId, rejectIntent, PendingIntent.FLAG_IMMUTABLE);
 
         Intent acceptIntent = new Intent(getApplicationContext(), NotificationProxyActivity.class);
         acceptIntent.setAction(Constants.ACTION_ACCEPT);


### PR DESCRIPTION
This pr is for the connection-service flavor. It fixes the decline notification call button.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
