### PR TITLE
[VBLOCKS-6245] Updated AGP version to 8.12.1 from 8.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
 
     ext.versions = [
             'java'               : JavaVersion.VERSION_11,
-            'androidGradlePlugin': '8.3.1',
+            'androidGradlePlugin': '8.12.1',
             'googleServices'     : '4.3.14',
             'compileSdk'         : 34,
             'buildTools'         : '34.0.0',

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Feb 22 17:01:57 EET 2024
+#Mon Mar 09 11:25:46 PDT 2026
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Updated quickstart to use the same version of Gradle/AGP as the sdk.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
