### PR TITLE
[VBLOCKS-6224] Fix crash in Release builds

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -2,6 +2,7 @@
 -keep class com.twilio.** { *; }
 -keep class tvo.webrtc.** { *; }
 -dontwarn tvo.webrtc.**
+-keep class org.jni_zero.** { *; }
 -keep class com.twilio.voice.** { *; }
 -keepattributes InnerClasses
 # needed with AGP 8.x


### PR DESCRIPTION
<!-- Describe your Pull Request -->
### Description
Added proguard rule to fix crash caused by "java.lang.ClassNotFoundException: org.jni_zero.JniInit"

Related ticket: https://twilio-engineering.atlassian.net/browse/VBLOCKS-6224

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
